### PR TITLE
Release v0.1.0-alpha.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.1.0-alpha.7 - 2026-08-03
+
 - Add explicit `required`, `not_required`, and `unclassified` Grounding Request
   decisions while preserving Grounding Protocol `1.0` compatibility.
 - Add read-only `opendomain assure` with advisory and enforced policy modes,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@echopath-labs/opendomain",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@echopath-labs/opendomain",
-      "version": "0.1.0-alpha.6",
+      "version": "0.1.0-alpha.7",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@echopath-labs/opendomain",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Git-native, evidence-backed domain semantics for AI agents.",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary

- prepare `@echopath-labs/opendomain@0.1.0-alpha.7`
- publish Grounding Assurance v1 release notes
- keep the npm release on the `alpha` dist-tag

## Validation

- Node.js 20: `npm test` (146 passed)
- Node.js 20: `opendomain validate` (25 documents, one non-blocking stale Candidate warning)
- OpenSpec: 7/7 records valid
- `npm audit`: 0 vulnerabilities
- `npm pack --dry-run`: 49 files, no private OpenSpec, Codex config, or npm credentials
- installed-package smoke: Profile, Prepare, and Assurance passed

## Release Boundary

- publish with `--tag alpha --provenance=false`
- keep `latest` unchanged
- create the tag and GitHub prerelease only after registry verification
