### PR TITLE
chore: prepare v0.1.0-alpha.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.1.0-alpha.8 - 2026-08-03
+
 - Add Node SEA standalone CLI builds for macOS arm64/x64, Linux x64, and
   Windows x64 so projects can initialize OpenDomain without installing Node.js
   or adding package metadata.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@echopath-labs/opendomain",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@echopath-labs/opendomain",
-      "version": "0.1.0-alpha.7",
+      "version": "0.1.0-alpha.8",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@echopath-labs/opendomain",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Git-native, evidence-backed domain semantics for AI agents.",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary

- bump package and lockfile version to 0.1.0-alpha.8
- freeze the standalone CLI distribution changes into the alpha.8 changelog section
- keep Unreleased open for later work

## Verification

- Node 20, 22, and 24.18.0: 178/178 tests pass on each runtime
- installed-package smoke passes for the alpha.8 tarball
- npm pack dry-run contains 59 public consumer files
- npm audit reports 0 vulnerabilities
- OpenDomain validation passes for 26 documents with one known stale Candidate warning
- macOS arm64 alpha.8 SEA build, full binary smoke, codesign verification, and architecture check pass
- OpenSpec validation passes 10/10 items

## Release boundary

This PR only prepares version metadata and release notes. It does not publish npm, create or push a tag, publish a GitHub Release, upload standalone release assets, or create the Homebrew Tap.