### PR TITLE
fix: update vulnerable fast-uri dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   least-privilege four-platform GitHub Actions release workflow.
 - Refresh `minimatch`'s transitive `brace-expansion` dependency to the patched
   `5.0.9` release.
+- Refresh Ajv's transitive `fast-uri` dependency to the patched `3.1.5`
+  release.
 
 ## 0.1.0-alpha.7 - 2026-08-03
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -580,9 +580,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- update Ajv's transitive `fast-uri` lockfile entry from 3.1.4 to patched 3.1.5
- record the dependency refresh in the alpha.8 changelog
- keep the public API and direct dependency ranges unchanged

## Release context

The alpha.8 publication preflight detected `GHSA-7p8r-x3mc-p8w7` as a high-severity npm audit finding. Publication is paused until this PR passes CI and review.

## Validation

- `volta run --node 20 npm test` (178/178)
- `npm audit --json` (0 vulnerabilities)
- `npm pack --dry-run --json --ignore-scripts --cache /private/tmp/opendomain-npm-cache` (59 expected files)
- `git diff --check`

## Domain Grounding Used

- Grounding Request: `not_required`
- Accepted IDs: none
- Candidate boundaries: none