### PR TITLE
fix: target repository for release uploads

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -114,4 +114,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: gh release upload "$RELEASE_TAG" dist/standalone/opendomain-* dist/standalone/SHA256SUMS.txt
+        run: gh release upload "$RELEASE_TAG" dist/standalone/opendomain-* dist/standalone/SHA256SUMS.txt --repo "$GITHUB_REPOSITORY"

--- a/tests/standalone-workflow.test.mjs
+++ b/tests/standalone-workflow.test.mjs
@@ -37,5 +37,7 @@ test("standalone workflow builds the declared matrix and isolates release permis
   const serializedPublish = JSON.stringify(workflow.jobs.publish.steps);
   assert.match(serializedPublish, /gh release upload/);
   assert.match(serializedPublish, /SHA256SUMS\.txt/);
+  assert.match(serializedPublish, /--repo/);
+  assert.match(serializedPublish, /GITHUB_REPOSITORY/);
   assert.doesNotMatch(serializedPublish, /--clobber/);
 });


### PR DESCRIPTION
## Summary

- pass `--repo "$GITHUB_REPOSITORY"` to the release-only `gh release upload` command
- preserve the no-checkout, least-privilege publish job
- add a workflow contract assertion so repository context cannot regress

## Incident

The alpha.8 release run `30878144138` built and smoked all four native targets and verified the complete checksum matrix, but the final upload job failed because its no-checkout workspace had no `.git` directory for `gh` repository discovery.

## Validation

- `node --test tests/standalone-workflow.test.mjs`
- `npm test` (178/178)
- `git diff --check`

## Domain Grounding Used

- Grounding Request: `not_required`
- Accepted IDs: none
- Candidate boundaries: none