### PR TITLE
chore: prepare 0.1.0-alpha.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.1.0-alpha.9 - 2026-08-04
+
 - Add a canonical Agent installation contract so Codex can install OpenDomain
   without changing host project package metadata, initialize its managed
   adapter, and prove readiness with diagnostics and validation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@echopath-labs/opendomain",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@echopath-labs/opendomain",
-      "version": "0.1.0-alpha.8",
+      "version": "0.1.0-alpha.9",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@echopath-labs/opendomain",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Git-native, evidence-backed domain semantics for AI agents.",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary
- bump package and lockfile to 0.1.0-alpha.9
- freeze the Agent-driven installation work under a dated alpha.9 changelog section
- keep Homebrew deferred and npm latest unchanged

## Local release gates
- 178 tests passed on Node.js 20.20.2, 22.23.2, and 24.18.0
- exact alpha.9 installed-package and global Agent bootstrap smokes passed
- npm dry-run: 60 public files, INSTALL.md included, private/process and maintainer-only files excluded
- npm audit: 0 vulnerabilities
- OpenDomain: 26 documents passed with the existing stale candidate-0002 warning
- OpenSpec: 11/11 items passed in the private nested repository
- macOS arm64 standalone build, Agent smoke, codesign, architecture, and version checks passed
- npm publication identity verified as chasechou007

## Publication boundary
Publication starts only after this PR passes CI and four-platform standalone verification, is squash-merged, and the merged main source is rechecked.