### PR TITLE
docs: add agent-first public guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Correct historical prerelease headings, dates, and notable workspace and
   release-boundary entries against published tags and npm registry history.
+- Reorganize public guidance around natural-language Codex adoption, add paired
+  Usage Guides, and verify public navigation and npm package contents.
 
 ## 0.1.0-alpha.9 - 2026-08-04
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,8 @@
 # OpenDomain Agent Installation Contract
 
 This is the canonical installation contract for shell-capable AI agents.
+For the human-facing workflow, see the [English Usage Guide](USAGE.md) or
+[Simplified Chinese Usage Guide](USAGE.zh-CN.md).
 
 When a user asks you to install OpenDomain in the current workspace, complete
 this workflow unless the user's instructions or repository policy are stricter.
@@ -61,8 +63,8 @@ Use the standalone fallback when a compatible npm environment is unavailable:
    user-writable executable directory on `PATH`, such as `$HOME/.local/bin`.
 6. Run `opendomain --version` and confirm the expected version.
 
-Supported standalone targets and minimum systems are listed in the project
-[README](README.md#standalone-binary-recommended). Never execute an asset when
+Supported standalone targets and minimum systems are listed under
+[Installation channels](USAGE.md#installation-channels). Never execute an asset when
 the matching checksum is absent or different. Do not silently use `sudo` to
 write to a system directory.
 

--- a/README.md
+++ b/README.md
@@ -6,336 +6,168 @@
 ![Node](https://img.shields.io/badge/node-%3E%3D20-0f766e.svg)
 ![Source](https://img.shields.io/badge/source-Markdown%20%2B%20YAML-2563eb.svg)
 
-> 简体中文说明: [README.zh-CN.md](README.zh-CN.md)
+> Simplified Chinese: [README.zh-CN.md](README.zh-CN.md)
 
-OpenDomain is a Git-native, evidence-backed, AI-maintainable domain semantic
-layer for software systems.
+OpenDomain is a Git-native, evidence-backed domain semantic layer for AI
+agents and human maintainers. It keeps long-lived business concepts, rules,
+lifecycles, events, evidence, and review state in repository-readable Markdown.
 
-It helps AI agents and human maintainers preserve long-lived business knowledge:
-what a business concept means, what it is not, which rules and lifecycles govern
-it, which evidence supports it, and which changes require human review.
+## Start With Codex
 
-## Boundary
+Open a shell-enabled Codex task in the project you want to model and say:
 
-OpenDomain, OpenSpec, and EchoPath are separate layers:
+> Install OpenDomain in this workspace. Follow the official Agent installation
+> contract, initialize the Codex integration, and prove that it is ready without
+> adding package metadata to this project.
+
+Codex should follow the [Agent Installation Contract](INSTALL.md), choose a
+compatible installation channel, run initialization or update, then verify the
+workspace with `doctor` and `validate`.
+
+After installation, keep working in natural language:
+
+> Explore the accepted business model for order cancellation. Do not modify
+> anything, and keep Candidate knowledge separate.
+
+> Reverse-model this existing project from its code and product documentation.
+> Put every uncertain business claim into a Candidate for review.
+
+> Review candidate-0001. Show its evidence, conflicts, and compatibility impact,
+> then wait for my decision.
+
+> Implement this change. Complete OpenDomain grounding before modifying
+> behavior, and report the accepted IDs and Candidate boundaries you used.
+
+The managed repository instructions and Codex Skills route these intentions to
+OpenDomain. Users do not need to choose routine CLI commands themselves. See the
+[complete Usage Guide](USAGE.md) for the observable workflow and recovery paths.
+
+## Human And Agent Responsibilities
+
+OpenDomain uses bounded Agent autonomy:
+
+| Human owns | Codex owns |
+| --- | --- |
+| Goals and expected outcomes | Reading repository instructions and environment |
+| Business boundaries and final meaning | Selecting the appropriate OpenDomain workflow |
+| Risk trade-offs and Candidate decisions | Running tools and preserving evidence boundaries |
+| Final acceptance | Reporting validation and unresolved gaps |
+
+AI-inferred knowledge never becomes accepted domain knowledge automatically.
+It starts as a Domain Candidate and requires an explicit human review decision.
+Codex cannot bypass shell, network, filesystem, repository, or approval policy.
+
+## Product Boundary
 
 ```text
 OpenDomain
-  Stable business semantics
-  What the business world is and which rules remain true over time
+  Long-lived business semantics
+  What the business world is and which rules remain true
 
-OpenSpec
+OpenSpec / Spec Kit / other planning tools
   Change intent and delivery specification
-  Why a change exists, what must be delivered, and how it is accepted
+  Why this change exists, what is delivered, and how it is accepted
 
 EchoPath
   Agent execution continuity
-  How agents recover, hand off, preserve context, and propose memory
+  How Agent work is recovered, handed off, and resumed
 ```
 
-OpenDomain should be referenced by OpenSpec, not copied into OpenSpec.
+OpenSpec and other planning sources may declare affected OpenDomain IDs. They
+should reference accepted domain knowledge, not duplicate its definitions.
 
-## Current Capabilities
+## What Gets Added To A Project
 
-This workspace now includes the first MVP slices:
+`opendomain init --tools codex` creates or updates only OpenDomain-owned
+resources:
 
-- Markdown + YAML front matter source files
-- Safe parser and Draft 2020-12 runtime schema validation
-- Safe-corpus gating before semantic closure, indexes, and grounding
-- CLI commands for project init, validation, ID listing, reference checks,
-  grounding, indexing, and demo
-- Package-manager-neutral Agent bootstrap with managed Codex Skills,
-  repository instructions, updates, and diagnostics
-- Standalone macOS, Linux, and Windows CLI binaries that require no Node.js
-  runtime or host-project package metadata
-- OpenSpec `affects_domain` grounding
-- Explicit `required`, `not_required`, and `unclassified` grounding decisions
-- Advisory and enforced Grounding Assurance for Codex and CI
-- Declarative repository-local Integration Profiles for structured non-OpenSpec
-  sources, with Native Mapping and Sidecar Domain Declaration
-- Deterministic file or bundle Source Units and explicit or automatic Profile
-  selection
-- Domain Candidate boundary checks
-- Semantic Retrieval Index as a derived read-first view
-- Deterministic workspace resolution with canonical `opendomain/` sources
-- OpenDomain dogfooding under `opendomain/`
+```text
+opendomain/
+  config.yaml
+  contexts/
+  concepts/
+  rules/
+  lifecycles/
+  events/
+  candidates/
 
-The source of truth remains Markdown with YAML front matter stored in Git.
-
-## Installation And Usage
-
-### Install With Codex
-
-In a shell-enabled Codex session, users can ask:
-
-> Install OpenDomain in this workspace.
-
-Codex should follow the canonical [Agent Installation Contract](INSTALL.md).
-It installs OpenDomain as a user tool, initializes or updates the
-repository-local Codex adapter, and proves readiness with `doctor` and
-`validate`. The workflow must not add a `package.json`, lockfile, dependency,
-or npm script to the host project. Network, shell, filesystem, and approval
-boundaries still apply and must be reported when unavailable.
-
-### Standalone Binary (Recommended)
-
-Download the binary and `SHA256SUMS.txt` for the same version from
-[GitHub Releases](https://github.com/echopath-labs/openDomain/releases):
-
-| Platform | Minimum system | Release asset |
-| --- | --- | --- |
-| macOS Apple silicon | macOS 13.5 | `opendomain-v<version>-darwin-arm64` |
-| macOS Intel | macOS 13.5 | `opendomain-v<version>-darwin-x64` |
-| Linux x64 | kernel 4.18, glibc 2.28, libstdc++ 6.0.25 (`GLIBCXX_3.4.25`) | `opendomain-v<version>-linux-x64` |
-| Windows x64 | Windows 10 or Server 2016 | `opendomain-v<version>-windows-x64.exe` |
-
-The standalone executable embeds the official Node.js 24.18.0 runtime and
-inherits its operating-system requirements. Alpine/musl is not supported in
-the initial matrix. See the
-[Node.js 24 platform requirements](https://github.com/nodejs/node/blob/v24.18.0/BUILDING.md#platform-list).
-
-Verify the downloaded file against its line in `SHA256SUMS.txt` before running
-it. Use `shasum -a 256 <asset>` on macOS, `sha256sum <asset>` on Linux, or
-`Get-FileHash <asset> -Algorithm SHA256` in PowerShell.
-
-On macOS or Linux, make the file executable, rename it, and place it on `PATH`:
-
-```bash
-chmod +x opendomain-v<version>-<target>
-mkdir -p "${XDG_BIN_HOME:-$HOME/.local/bin}"
-install -m 0755 opendomain-v<version>-<target> "${XDG_BIN_HOME:-$HOME/.local/bin}/opendomain"
+AGENTS.md                              managed OpenDomain block
+.codex/skills/opendomain-explore/     generated Skill
+.codex/skills/opendomain-model/       generated Skill
+.codex/skills/opendomain-review/      generated Skill
 ```
 
-Ensure that the selected user-owned directory is on `PATH`.
+The command preserves user-owned content. It does not create or modify the host
+project's `package.json`, lockfile, dependencies, or npm scripts. Whether these
+files are committed is the project's decision; they are compatible with normal
+Git versioning.
 
-On Windows, rename the asset to `opendomain.exe` and place it in a directory on
-`PATH`. Then initialize a project without adding Node.js metadata:
+## Manual Installation
+
+Most users should ask Codex to install OpenDomain. The same channels are
+available manually.
+
+### npm alpha channel
+
+Use npm when Node.js 20 or Node.js 22 and newer is already available:
 
 ```bash
+npm install --global @echopath-labs/opendomain@alpha
 opendomain --version
 opendomain init --tools codex
 opendomain doctor
 opendomain validate
 ```
 
-Upgrade by downloading, verifying, and replacing the binary with the asset from
-a newer release. The initial macOS binaries are ad-hoc signed but not notarized;
-Windows binaries are not Authenticode signed. Checksums detect file changes but
-do not establish publisher identity. Homebrew is not currently an installation
-channel and will be reconsidered after the project reaches stable distribution
-maturity.
+The explicit `@alpha` tag is required during prerelease development.
 
-### npm (Alternative)
+### Standalone binary
 
-Users who already manage a Node.js tool environment can install the same CLI
-from npm:
+When a compatible npm environment is unavailable, download the matching binary
+and `SHA256SUMS.txt` from [GitHub Releases](https://github.com/echopath-labs/openDomain/releases).
+Verify the exact checksum before execution.
 
-```bash
-npm install -g @echopath-labs/opendomain@alpha
-opendomain init --tools codex
-opendomain doctor
-opendomain validate
-```
+| Target | Minimum system |
+| --- | --- |
+| `darwin-arm64` / `darwin-x64` | macOS 13.5 |
+| `linux-x64` | kernel 4.18, glibc 2.28, `GLIBCXX_3.4.25` |
+| `windows-x64.exe` | Windows 10 or Windows Server 2016 |
 
-The explicit `@alpha` tag is required during the prerelease period so npm does
-not resolve an older `latest` dist-tag.
+The initial macOS binaries are ad-hoc signed but not notarized. Windows binaries
+are not Authenticode signed. Checksums detect file changes but do not establish
+publisher identity. See [Installation channels](USAGE.md#installation-channels)
+for verification and upgrade steps.
 
-Both distribution channels run the same CLI. OpenDomain does not
-create or modify the host project's `package.json`, lockfile, dependency list,
-or npm scripts. `init --tools codex` adds the canonical `opendomain/` workspace,
-generated `.codex/skills/opendomain-*` adapters, and one managed OpenDomain
-block in `AGENTS.md`. Existing instructions outside that block remain owned by
-the project.
+## Current Capabilities
 
-After initialization, users can ask Codex to explore or model the domain,
-review a Candidate, or implement a change. The generated Skills and managed
-instructions select the appropriate CLI operations; direct commands remain
-available for CI and diagnostics.
+The current alpha includes:
 
-If workspace configuration later deselects an adapter, `doctor` reports any
-remaining generated Skills and `update` removes only files that still carry
-OpenDomain generation ownership metadata.
+- Markdown with YAML front matter as the source of truth;
+- schema validation and reference integrity checks;
+- accepted concepts, rules, lifecycles, events, and evidence;
+- Candidate-first AI inference with explicit human review;
+- deterministic Semantic Closure and derived read-first indexes;
+- Grounding Request, Grounding Pack, and advisory/enforced Assurance;
+- built-in OpenSpec grounding and declarative Integration Profiles;
+- managed Codex instructions, Skills, updates, and diagnostics;
+- npm and standalone CLI distribution without host package metadata.
 
-### Source Checkout
+OpenDomain is suitable for bounded trials and public iteration. The format and
+CLI may still change before a stable release, and it should not yet be the sole
+governance source for production-critical domain decisions.
 
-Maintainers can also run it from a source checkout.
+## Public Resources
 
-Common commands:
-
-```bash
-npm run opendomain -- help
-npm run opendomain -- init
-npm run opendomain -- init --tools codex
-npm run opendomain -- update
-npm run opendomain -- doctor
-npm run opendomain -- validate
-npm run prepare:demo
-(cd examples/erp && node ../../bin/opendomain.mjs assure openspec/changes/order-cancellation/spec.md)
-npm run opendomain -- integrations validate
-npm run opendomain -- integrations list
-npm run opendomain -- candidate list examples/erp
-npm run opendomain -- candidate show candidate-0001-order-lifecycle examples/erp
-npm run opendomain -- index build examples/erp --out /tmp/erp-index.json
-npm run opendomain -- index query sales.order --index /tmp/erp-index.json
-npm test
-```
-
-Commands without a source path resolve the current project's canonical
-`opendomain/` workspace. During `0.x`, a legacy `domain/` workspace remains
-readable when the canonical root is absent. If both exist, `opendomain/` wins
-with a warning; the roots are never merged. Pass a file or directory explicitly
-when validating a fixture or external corpus such as `examples/erp`.
-
-An OpenSpec-style source unit can declare an explicit grounding decision:
-
-```yaml
-grounding:
-  status: required
-  rationale: Cancellation is constrained by accepted order semantics.
-affects_domain:
-  concepts:
-    - sales.order
-  rules: []
-  lifecycles: []
-  events: []
-```
-
-The supported statuses are `required`, `not_required`, and `unclassified`.
-`not_required` requires a non-whitespace rationale and forbids every OpenDomain
-ID. Empty IDs under `required` represent an incomplete `domain_model_gap`;
-empty IDs never imply `not_required`.
-Every affected ID must also match its declared category: `concepts` resolve to
-`domain_concept`, `rules` to `business_rule`, `lifecycles` to `lifecycle`, and
-`events` to `domain_event`. IDs must contain non-whitespace text. When a
-`feature_spec` is included in an `opendomain validate` target, validation applies
-the same grounding-decision rules used by `prepare` and `assure`.
-Unknown affected-domain categories are invalid. A source recognized as OpenSpec
-but failing validation does not fall through to a matching Profile, and external
-Grounding Packs cannot contain duplicate evidence or Candidate IDs.
-
-Run the read-only preflight locally or in CI:
-
-```bash
-opendomain assure <source-unit>
-opendomain assure <source-unit> --mode enforced --json
-```
-
-Advisory mode warns but exits zero for `unclassified` and `domain_model_gap`.
-Enforced mode fails those incomplete states. Malformed input, contradictions,
-broken references, integration ambiguity, and accepted/Candidate trust boundary
-violations fail in both modes. Run `opendomain init` before adopting Assurance
-in an existing project. The result reports observed evidence; it does not prove
-Agent comprehension or independently attest a historical repository state.
-An `unclassified` request still validates every affected ID it already declares;
-missing or mistyped evidence fails in both modes rather than becoming advisory.
-The Result Schema binds `prepared` to `required`, `not_required` to an explicit
-evidence-free skip, and `incomplete` to `required` or `unclassified`.
-It validates shape and expressible local invariants, including that `pass`
-contains no findings or Pack diagnostics and that `warn` contains no error
-findings or Pack errors. It does not re-evaluate semantic coverage in persisted
-or third-party JSON; CI must run `opendomain assure` against the current
-workspace.
-Affected concepts, rules, lifecycles, and events use the same canonical dotted
-ID grammar as their OpenDomain source objects. Grounding Pack evidence IDs are
-validated against the grammar for their declared type.
-`read_first` accepts only bounded contexts, concepts, rules, lifecycles, and
-events, and every evidence path must contain non-whitespace text;
-`domain_candidate` entries remain confined to Candidate boundaries.
-Paths rendered by Assurance are normalized single-line values without leading
-or trailing whitespace or terminal control characters. Evidence and Candidate
-paths must also be normalized repository-relative paths without absolute roots,
-backslashes, or `.` / `..` traversal segments. External diagnostic text uses the
-same control-character boundary, and schema-derived finding text escapes unsafe
-property-name controls before terminal output.
-Caller-supplied or persisted Grounding Packs cannot establish completed
-Assurance, even when their shape is valid. Run `opendomain assure` against the
-current Source Unit and workspace so accepted evidence and Semantic Closure are
-regenerated from validated OpenDomain sources.
-`preparation` reports only its state. The Grounding Request and classification
-live in `grounding_pack.grounding_request`; evidence IDs, types, and paths live
-in `grounding_pack.read_first` and `grounding_pack.candidate_boundaries`. IDs
-cannot appear in both evidence collections, and the Result carries no divergent
-request, classification, or evidence summary.
-Each Candidate boundary uses the Candidate ID, lifecycle status, and confidence
-contract, and its `target_id` must identify accepted `read_first` evidence in
-that same Pack. Human-readable Assurance output preserves that review status,
-including final `rejected`, `superseded`, or `deprecated` decisions.
-
-Repository-local Integration Profiles can normalize explicit structured intent
-and OpenDomain IDs from non-OpenSpec sources. Profiles do not scan prose, infer
-IDs, execute code, create Candidates, or promote accepted knowledge. The
-machine-readable contracts are published under `schemas/`.
-Profile v1 has no grounding-decision mapping, so its trusted Request Builder
-normalizes requests to `unclassified`; use advisory Assurance, or an integration
-with an explicit decision, until that contract is extended.
-
-## Project Status
-
-OpenDomain is early alpha. The current repository is ready for public iteration,
-but the format and CLI may still change.
-
-Public entry points:
-
+- [Usage Guide](USAGE.md)
+- [Agent Installation Contract](INSTALL.md)
+- [ERP example](examples/erp/README.md)
+- [Changelog](CHANGELOG.md)
 - [Contributing](CONTRIBUTING.md)
 - [Security policy](SECURITY.md)
-- [Changelog](CHANGELOG.md)
 - `schemas/` for machine-readable contracts
-- `examples/erp/` for synthetic integration fixtures
 
-License: MIT.
+Maintainer planning records are private process material and are not shipped in
+the public repository or npm package. The OpenSpec fixture under `examples/erp/`
+is synthetic interoperability data.
 
-## Repository Map
-
-```text
-.
-├── README.md
-├── opendomain/
-│   ├── integrations/profiles/
-│   └── README.md
-├── examples/
-│   └── erp/
-├── schemas/
-└── tests/
-```
-
-## Working Rule
-
-AI-discovered domain knowledge starts as a Candidate. It does not become
-accepted OpenDomain knowledge until a human reviewer approves it.
-
-## MVP Grounding Demo
-
-The first MVP slice demonstrates Order Cancellation grounding:
-
-```bash
-npm test
-npm run prepare:demo
-npm run opendomain -- validate examples/erp
-npm run demo
-```
-
-## Semantic Retrieval Index
-
-The index is a derived read-first view. It helps Codex find accepted source
-files and related Candidate boundaries, but it is not source of truth.
-
-## Dogfooding
-
-OpenDomain now models part of its own product semantics under `opendomain/`.
-
-```bash
-npm run opendomain -- validate
-```
-
-## Planning Split
-
-Use this rule when preserving planning:
-
-- `opendomain/`: long-lived OpenDomain semantics
-- `opendomain/candidates/`: proposed or inferred semantics
-- a project's optional `openspec/changes/`: future delivery work
-
-Maintainer OpenSpec, PRDs, ADRs, dogfooding, review notes, roadmaps, and release
-procedures are development-process records. They are intentionally excluded
-from this public repository and from the npm package. The OpenSpec files under
-`examples/erp/` are synthetic interoperability fixtures, not project records.
+OpenDomain is licensed under the [MIT License](LICENSE).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,549 +1,160 @@
 # OpenDomain
 
-一个面向 AI Agent 和人类维护者的 Git 原生、证据驱动领域语义层。
-
 [![CI](https://github.com/echopath-labs/openDomain/actions/workflows/ci.yml/badge.svg)](https://github.com/echopath-labs/openDomain/actions/workflows/ci.yml)
 ![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)
 ![Status](https://img.shields.io/badge/status-alpha-f59e0b.svg)
 ![Node](https://img.shields.io/badge/node-%3E%3D20-0f766e.svg)
 ![Source](https://img.shields.io/badge/source-Markdown%20%2B%20YAML-2563eb.svg)
 
-> English version: [README.md](README.md)
+> English: [README.md](README.md)
 
-OpenDomain 用来在软件仓库中持续沉淀长期业务知识：一个业务概念是什么、不是什么，哪些规则长期成立，对象有哪些生命周期，哪些证据支持这些知识，以及哪些内容需要人类审查后才能成为可信语义。
+OpenDomain 是面向 AI Agent 与人类维护者的 Git 原生、证据驱动领域语义层。它用
+仓库内可读的 Markdown 长期保存业务概念、规则、生命周期、事件、证据和审查状态。
 
-它的核心目标是让 Codex、Claude Code、Cursor、Gemini CLI 等 AI 编码 Agent 在修改系统前，能够稳定读取业务语义，而不是临时从代码、数据库、接口或聊天上下文里猜业务含义。
+## 从 Codex 开始
 
-OpenDomain 当前是 early alpha。格式和 CLI 仍可能演进，但已经具备第一批 MVP 能力。
+在需要建模的项目中打开一个可执行 Shell 的 Codex 任务，然后直接说：
 
-## 为什么需要它
+> 帮我在当前工作区安装 OpenDomain。遵循官方 Agent 安装契约，初始化 Codex
+> 集成并证明它已经可用，不要给这个项目添加 package metadata。
 
-AI 编码 Agent 很容易从实现细节里推断业务语义，但实现结构不等于业务世界。
+Codex 应按照 [Agent 安装契约](INSTALL.md)选择兼容的安装渠道，执行初始化或更新，
+最后通过 `doctor` 和 `validate` 验证工作区。
 
-没有稳定的领域语义层时，团队会反复遇到这些问题：
+安装后继续用自然语言工作：
 
-- Agent 把数据库表、API shape 或代码结构误认为业务模型；
-- 长期业务规则散落在代码、测试、文档和历史 Spec 里；
-- 同一个概念在不同上下文中被混用；
-- 某次 Feature 的设计选择被误当成永久规则；
-- AI 推断出的“知识”缺少证据、状态和人类审查；
-- 一年后很难重新找到相关业务模型、规则和历史变更。
+> 只读了解订单取消相关的 accepted 业务模型，不要修改任何内容，并把 Candidate
+> 与 accepted knowledge 分开。
 
-OpenDomain 提供一种轻量方式，把这些长期语义放回 Git，并让 Agent 能通过结构化入口读取。
+> 根据这个既有项目的代码和产品文档逆向梳理业务模型，所有不确定的业务判断先写成
+> Candidate 等我审查。
 
-## OpenDomain 是什么
+> 审查 candidate-0001，列出证据、冲突和兼容性影响，然后等我决定。
 
-OpenDomain 是：
+> 实现这个变更，修改行为前先完成 OpenDomain grounding，最后报告使用过的
+> accepted IDs 和 Candidate boundaries。
 
-- Git-native：source of truth 是仓库中的 Markdown 文件；
-- evidence-backed：重要语义必须有证据；
-- AI-maintainable：结构化到足够让 Agent 解析、检索和引用；
-- human-reviewable：普通 Git diff 就能审查；
-- domain-focused：记录长期业务语义，而不是一次性任务说明。
+受管仓库指令和 Codex Skills 会把这些意图路由到 OpenDomain。正常工作流不需要用户
+自己选择 CLI 命令。完整过程和恢复方式见[简体中文使用指南](USAGE.zh-CN.md)。
 
-它回答的是：
+## 人与 Agent 的责任
 
-```text
-业务世界是什么？
-哪些概念长期存在？
-它们属于哪个业务上下文？
-哪些规则、不变量和生命周期必须长期成立？
-哪些知识已经被人类确认？
-哪些只是待审 Candidate？
-```
+OpenDomain 采用有边界的 Agent 自主性：
 
-## 与 OpenSpec / EchoPath 的边界
+| 人负责 | Codex 负责 |
+| --- | --- |
+| 目标与期望结果 | 阅读仓库指令和运行环境 |
+| 业务边界与最终语义 | 选择合适的 OpenDomain 工作流 |
+| 风险取舍和 Candidate 决定 | 执行工具并维持证据边界 |
+| 最终验收 | 报告验证结果和未解决缺口 |
 
-OpenDomain、OpenSpec 和 EchoPath 是三个不同层次：
+AI 推断出的知识不会自动变成 accepted domain knowledge。它必须先进入 Domain
+Candidate，并由人明确作出审查决定。Codex 也不能绕过 Shell、网络、文件系统、
+仓库规则或审批边界。
+
+## 产品边界
 
 ```text
 OpenDomain
   长期业务语义
   说明业务世界是什么，哪些规则长期成立
 
-OpenSpec
+OpenSpec / Spec Kit / 其他规划工具
   变更意图与交付规范
-  说明这次为什么改、要交付什么、如何验收
+  说明这次为什么改、交付什么、如何验收
 
 EchoPath
   Agent 执行连续性
-  说明 Agent 如何恢复、交接、保留执行上下文
+  说明 Agent 工作如何恢复、交接和继续
 ```
 
-判断一条知识放在哪里，可以先用这条规则：
+OpenSpec 等规划来源可以声明受影响的 OpenDomain ID，但应该引用 accepted domain
+knowledge，而不是复制其定义。
 
-```text
-如果一条知识在当前 Feature 结束后仍长期成立，它更可能属于 OpenDomain。
-如果一条知识只解释某次变更的动机、设计、任务或验收，它属于 OpenSpec。
-```
+## 项目中会增加什么
 
-OpenSpec 应该引用 OpenDomain ID，而不是复制 OpenDomain 定义。
-
-## 适合谁使用
-
-OpenDomain 适合：
-
-- 使用 AI Agent 长期维护复杂业务系统的团队；
-- 希望把业务概念、规则、生命周期和证据放进 Git 的维护者；
-- 需要让 Agent 在改代码前先读取业务语义的项目；
-- 需要区分 accepted knowledge 和 AI-inferred Candidate 的团队；
-- 正在使用 OpenSpec，并希望 Feature spec 能引用长期业务模型的项目。
-
-它特别适合 ERP、CRM、WMS、MES、财务、供应链、订单、库存、制造、支付、权限等业务规则密集的系统。
-
-## 这个项目现在能做什么
-
-当前 MVP 已包含：
-
-- Markdown + YAML front matter 领域语义文件；
-- Bounded Context、Domain Concept、Business Rule、Lifecycle、Domain Event、Domain Candidate；
-- 安全 parser 和 Draft 2020-12 Runtime Schema 校验；
-- 在 Semantic Closure、index 和 grounding 前执行安全语料门禁；
-- CLI 命令：init、validate、ids list、refs check、prepare、assure、integrations、
-  index、update、doctor、demo；
-- 不要求宿主 `package.json` 的 Agent bootstrap，以及受管 Codex Skills 与
-  `AGENTS.md` 指令区块；
-- 不要求预装 Node.js、也不向宿主项目引入 package metadata 的 macOS、Linux 和
-  Windows 独立 CLI 二进制；
-- OpenSpec `affects_domain` grounding；
-- 显式 `required` / `not_required` / `unclassified` Grounding Request；
-- 面向 Codex 与 CI 的 advisory / enforced Grounding Assurance；
-- 面向结构化非 OpenSpec 来源的 repository-local 声明式 Integration Profile；
-- Native Mapping、Sidecar Domain Declaration，以及确定性的 file / bundle
-  Source Unit；
-- Candidate 边界检查；
-- Semantic Retrieval Index，作为派生的 read-first 检索视图；
-- 以 canonical `opendomain/` 为入口的确定性工作区解析；
-- ERP Order Cancellation 示例；
-- OpenDomain 自己的 self-model dogfooding。
-
-## 非目标
-
-OpenDomain 当前不做：
-
-- OpenSpec 的领域版复制品；
-- 数据库 schema 文档；
-- 长篇业务百科；
-- 未经审查的 AI memory；
-- 自动接受 AI 推断的知识库；
-- 以图数据库、embedding index 或 MCP resource 作为 source of truth；
-- SaaS 协作平台；
-- OWL / RDF / SPARQL 默认建模入口。
-
-这些能力未来可以作为导出、派生视图或生态集成出现，但 MVP 的 source of truth 仍然是 Git 中的 Markdown 文件。
-
-## 30 秒开始
-
-### 让 Codex 安装
-
-在可以执行 Shell 的 Codex 会话中，可以直接提出：
-
-> 帮我在当前工作区安装 OpenDomain。
-
-Codex 应遵循正式的 [Agent 安装契约](INSTALL.md)，把 OpenDomain 安装为用户工具，
-初始化或更新仓库局部的 Codex adapter，并通过 `doctor` 和 `validate` 提供可核验的
-完成证据。整个过程不得向宿主项目添加 `package.json`、lockfile、依赖或 npm
-scripts。网络、Shell、文件写入或审批权限不可用时，Codex 必须明确报告阻塞原因。
-
-### 独立二进制（推荐）
-
-从 [GitHub Releases](https://github.com/echopath-labs/openDomain/releases) 下载同一
-版本的目标平台文件和 `SHA256SUMS.txt`：
-
-| 平台 | 最低系统要求 | Release 文件 |
-| --- | --- | --- |
-| macOS Apple silicon | macOS 13.5 | `opendomain-v<version>-darwin-arm64` |
-| macOS Intel | macOS 13.5 | `opendomain-v<version>-darwin-x64` |
-| Linux x64 | kernel 4.18、glibc 2.28、libstdc++ 6.0.25（`GLIBCXX_3.4.25`） | `opendomain-v<version>-linux-x64` |
-| Windows x64 | Windows 10 或 Server 2016 | `opendomain-v<version>-windows-x64.exe` |
-
-独立二进制内嵌官方 Node.js 24.18.0 运行时，因此继承其操作系统要求。首批矩阵不
-支持 Alpine/musl。详见
-[Node.js 24 平台要求](https://github.com/nodejs/node/blob/v24.18.0/BUILDING.md#platform-list)。
-
-运行前先核对文件 SHA-256 是否与 `SHA256SUMS.txt` 中对应行一致。macOS 可使用
-`shasum -a 256 <asset>`，Linux 可使用 `sha256sum <asset>`，PowerShell 可使用
-`Get-FileHash <asset> -Algorithm SHA256`。
-
-macOS 或 Linux 用户需要添加执行权限并放入 `PATH`：
-
-```bash
-chmod +x opendomain-v<version>-<target>
-mkdir -p "${XDG_BIN_HOME:-$HOME/.local/bin}"
-install -m 0755 opendomain-v<version>-<target> "${XDG_BIN_HOME:-$HOME/.local/bin}/opendomain"
-```
-
-需要确保所选的用户目录已经加入 `PATH`。
-
-Windows 用户可将文件改名为 `opendomain.exe`，再放入 `PATH` 中的目录。随后直接在
-项目中初始化，不需要 Node.js、`package.json` 或 npm scripts：
-
-```bash
-opendomain --version
-opendomain init --tools codex
-opendomain doctor
-opendomain validate
-```
-
-升级时下载新版本、重新校验 SHA-256，然后替换旧二进制。首批 macOS 产物只做
-ad-hoc signing，尚未 notarize；Windows 产物尚未做 Authenticode 签名。checksum
-可以发现文件变化，但不等价于发布者身份证明。Homebrew 当前不是可用安装渠道，
-将在项目达到稳定分发成熟度后重新评估。
-
-### npm（可选）
-
-已经维护 Node.js 工具环境的用户，也可以安装同一套 CLI。OpenDomain 的 npm 包名是
-`@echopath-labs/opendomain`，CLI 命令是 `opendomain`。
-
-全局安装 CLI：
-
-```bash
-npm install -g @echopath-labs/opendomain@alpha
-opendomain init --tools codex
-opendomain doctor
-opendomain validate
-```
-
-预发布阶段必须显式使用 `@alpha`，避免 npm 解析到较旧的 `latest` dist-tag。
-
-两种分发渠道运行相同 CLI。OpenDomain 不会在宿主项目中创建或修改
-`package.json`、lockfile、依赖声明或 npm scripts。`init --tools codex` 会创建
-canonical `opendomain/`、生成 `.codex/skills/opendomain-*`，并在 `AGENTS.md`
-中维护一个有明确边界的 OpenDomain 区块；区块之外的项目指令保持原样。
-
-初始化后，用户可以直接要求 Codex 浏览或建模业务、审查 Candidate，或者实现一项
-变更。生成的 Skills 和托管指令负责选择 CLI 操作；直接命令主要保留给 CI、诊断和
-高级使用。
-
-如果 workspace config 后续取消选择某个 adapter，`doctor` 会报告残留的 generated
-Skills，`update` 只移除仍带 OpenDomain generation ownership metadata 的文件。
-
-### 源码开发
-
-维护者也可以从源码运行。
-
-克隆仓库：
-
-```bash
-git clone https://github.com/echopath-labs/openDomain.git
-cd openDomain
-```
-
-查看 CLI：
-
-```bash
-npm run opendomain -- help
-```
-
-初始化 OpenDomain 目录：
-
-```bash
-npm run opendomain -- init
-npm run opendomain -- init --tools codex
-npm run opendomain -- update
-npm run opendomain -- doctor
-```
-
-运行测试：
-
-```bash
-npm test
-```
-
-验证 OpenDomain 文件：
-
-```bash
-npm run opendomain -- validate
-```
-
-运行 ERP 示例验证：
-
-```bash
-npm run opendomain -- validate examples/erp
-(cd examples/erp && node ../../bin/opendomain.mjs assure openspec/changes/order-cancellation/spec.md)
-```
-
-为一个 Feature 准备 Codex grounding：
-
-```bash
-npm run prepare:demo
-```
-
-构建并查询 Semantic Retrieval Index：
-
-```bash
-npm run opendomain -- index build examples/erp --out /tmp/erp-index.json
-npm run opendomain -- index query sales.order --index /tmp/erp-index.json
-```
-
-## 核心工作流
-
-### 1. 写长期业务语义
-
-把长期成立的业务知识写入项目根目录的 `opendomain/`：
+`opendomain init --tools codex` 只创建或更新 OpenDomain 拥有的资源：
 
 ```text
 opendomain/
+  config.yaml
   contexts/
   concepts/
   rules/
   lifecycles/
   events/
   candidates/
-  integrations/
-    profiles/
+
+AGENTS.md                              受管 OpenDomain 区块
+.codex/skills/opendomain-explore/     生成的 Skill
+.codex/skills/opendomain-model/       生成的 Skill
+.codex/skills/opendomain-review/      生成的 Skill
 ```
 
-不传 source path 时，CLI 会从当前项目根目录解析工作区：
+命令会保留用户拥有的内容，不会创建或修改宿主项目的 `package.json`、lockfile、依赖
+或 npm scripts。是否提交这些文件由项目自己决定；它们可以被正常 Git 版本管理。
 
-- 优先使用 canonical `opendomain/`；
-- 在 `0.x` 期间，只有 `domain/` 时会兼容读取并给出迁移提示；
-- 两个根目录同时存在时只读取 `opendomain/`，发出 warning，不合并语料；
-- 默认只读取六类语义目录，不扫描 `examples/`、`generated/` 或 integration 配置；
-- 验证示例、fixture 或外部语料时，需要显式传入文件或目录。
+## 手动安装
 
-例如 `sales.order` 应该说明 Order 在 Sales context 中是什么意思，它不是什么，它受哪些规则和生命周期约束，以及证据是什么。
+大多数用户只需要让 Codex 安装。也可以手动使用相同渠道。
 
-### 2. 用 OpenSpec 引用 OpenDomain
+### npm alpha 渠道
 
-Feature spec 通过 `affects_domain` 引用 OpenDomain ID：
-
-```yaml
----
-type: feature_spec
-id: spec.order-cancellation
-name: Order cancellation
-status: proposed
-grounding:
-  status: required
-  rationale: Cancellation behavior is constrained by accepted order semantics.
-affects_domain:
-  concepts:
-    - sales.order
-  rules:
-    - sales.confirmed-order-cannot-be-deleted
-  lifecycles:
-    - sales.order-lifecycle
-  events:
-    - sales.order-confirmed
----
-```
-
-OpenSpec 描述这次变更，OpenDomain 描述长期语义。
-
-### 3. Codex 先 grounding 再实现
-
-在执行 `opendomain init --tools codex` 后，repository-local Codex Skills 会分别处理
-只读领域探索、Candidate-first 建模和 Candidate 审查；`AGENTS.md` 托管区块要求
-Codex 在实现非平凡 Feature 前默认执行只读 Assurance：
+已有 Node.js 20，或 Node.js 22 及以上环境时使用 npm：
 
 ```bash
-opendomain assure <feature-spec-or-dir>
-opendomain assure <feature-spec-or-dir> --mode enforced --json
+npm install --global @echopath-labs/opendomain@alpha
+opendomain --version
+opendomain init --tools codex
+opendomain doctor
+opendomain validate
 ```
 
-`assure` 会复用 `prepare` 的解析和 Semantic Closure。只需要查看原始 Grounding
-Pack、而不需要策略判断时，可以单独运行
-`opendomain prepare <feature-spec-or-dir>`。
+预发布阶段必须显式使用 `@alpha`。
 
-Grounding Requirement 有三个显式状态：
+### 独立二进制
 
-| 状态 | 含义 |
+没有兼容 npm 环境时，从 [GitHub Releases](https://github.com/echopath-labs/openDomain/releases)
+下载匹配的二进制和 `SHA256SUMS.txt`，执行前必须核对准确 checksum。
+
+| Target | 最低系统 |
 | --- | --- |
-| `required` | 这次工作受长期领域语义约束，需要准备 accepted context |
-| `not_required` | 这次工作不涉及领域语义；必须提供非空白 rationale，且不能声明任何 OpenDomain ID |
-| `unclassified` | Agent 或维护者尚无足够证据完成判断 |
+| `darwin-arm64` / `darwin-x64` | macOS 13.5 |
+| `linux-x64` | kernel 4.18、glibc 2.28、`GLIBCXX_3.4.25` |
+| `windows-x64.exe` | Windows 10 或 Windows Server 2016 |
 
-每个 affected ID 还必须与声明类别一致：`concepts` 对应 `domain_concept`，
-`rules` 对应 `business_rule`，`lifecycles` 对应 `lifecycle`，`events` 对应
-`domain_event`，并且 ID 必须包含非空白文本。当 `opendomain validate` 的目标中
-包含 `feature_spec` 时，它会应用与 `prepare`、`assure` 相同的 grounding decision
-规则。
+首批 macOS 二进制采用 ad-hoc 签名但未 notarize；Windows 二进制没有 Authenticode
+签名。Checksum 可以发现文件变化，但不能证明发布者身份。校验和升级步骤见
+[安装渠道](USAGE.zh-CN.md#安装渠道)。
 
-未知 affected-domain 类别属于非法输入。一个已经被识别为 OpenSpec、但校验失败的
-来源不会回退成匹配的 Profile；外部 Grounding Pack 也不能包含重复的 evidence 或
-Candidate ID。
+## 当前能力
 
-Assurance 将状态判断、准备结果和执行策略分开报告：
+当前 alpha 已包含：
 
-| 准备结果 | advisory | enforced |
-| --- | --- | --- |
-| `prepared` / 合法 `not_required` | `pass` | `pass` |
-| `unclassified` / `domain_model_gap` | `warn`，exit 0 | `fail`，exit 1 |
-| 格式错误、矛盾或断裂引用 | `fail`，exit 1 | `fail`，exit 1 |
+- Markdown + YAML front matter source of truth；
+- Schema 校验与引用完整性检查；
+- accepted 概念、规则、生命周期、事件与证据；
+- Candidate-first AI 推断和显式人工审查；
+- 确定性 Semantic Closure 与派生 read-first index；
+- Grounding Request、Grounding Pack 和 advisory/enforced Assurance；
+- 内置 OpenSpec grounding 与声明式 Integration Profile；
+- 受管 Codex 指令、Skills、更新和诊断；
+- 不引入宿主 package metadata 的 npm 与独立 CLI 分发。
 
-`unclassified` Request 仍会校验所有已经声明的 affected ID；缺失 evidence 或类型
-不匹配属于 malformed Pack，在 advisory 与 enforced 下都会 fail。
-
-Result Schema 会将 `prepared` 绑定到 `required`，将 `not_required` 绑定到无 evidence
-的显式跳过，并限制 `incomplete` 只能对应 `required` 或 `unclassified`。
-它只校验结构与可表达的局部不变量，包括 `pass` 不得携带 finding 或 Pack
-diagnostic，以及 `warn` 不得携带 error finding 或 Pack error；它不会重新验证
-持久化或第三方 JSON 的语义覆盖。CI 必须针对当前 workspace 重新运行
-`opendomain assure`。
-受影响的 concept、rule、lifecycle 与 event ID 必须符合其 OpenDomain source object
-使用的 canonical dotted ID 格式；Grounding Pack evidence ID 也会按声明类型校验。
-`read_first` 只允许 bounded context、concept、rule、lifecycle 与 event，且每个
-evidence path 都必须包含非空白字符；`domain_candidate` 必须留在 Candidate
-boundaries 中。Assurance 输出的 path 必须是无首尾空白、换行或终端控制字符的
-单行值；evidence 与 Candidate path 还必须是无绝对根、反斜杠及 `.` / `..` 穿越
-段的规范化仓库相对路径。外部 diagnostic 文本也遵循相同控制字符边界；schema
-派生的 finding 会先转义属性名中的控制字符，再进入终端输出。调用方直接提供或
-持久化的 Grounding Pack 即使结构合法，也不能建立 completed Assurance；必须针对
-当前 Source Unit 和 workspace 重新运行 `opendomain assure`，从已校验的 OpenDomain
-source 重新生成 accepted evidence 与 Semantic Closure。`preparation` 只报告状态，Grounding Request 与 classification
-只存在于 `grounding_pack.grounding_request`，evidence ID、类型和路径只存在于
-`grounding_pack.read_first` 与 `grounding_pack.candidate_boundaries`。同一个 ID
-不能同时出现在两个 evidence 集合中，Assurance Result 不再携带可能相互矛盾的
-request、classification 或 evidence 摘要。
-每个 Candidate boundary 都必须符合 Candidate ID、生命周期状态与 confidence
-约束，且 `target_id` 必须指向同一 Pack 中的 accepted `read_first` evidence。
-Assurance 文本输出会保留该 review status，包括最终的 `rejected`、`superseded`
-或 `deprecated` 决定。
-
-存量项目应先运行 `opendomain init`。初始化后即使还没有 accepted knowledge，
-`required` 加空引用也会被识别为 `domain_model_gap`；完全缺少 OpenDomain workspace
-则是环境错误。Assurance Result 报告本次执行观察到的事实，但不能证明 Agent 已经
-理解模型，也不能独立证明某个历史仓库状态。
-
-对于其他结构化规划格式，可以在
-`opendomain/integrations/profiles/` 中声明 repository-local Profile：
-
-```bash
-opendomain integrations validate
-opendomain integrations list
-opendomain prepare --profile <profile-id> <structured-file-or-bundle>
-```
-
-未显式选择时，只有一个 built-in adapter 或 Profile 匹配才会继续；多重匹配会
-失败，不按优先级猜测。Profile 只归一化来源中明确存在的 intent 和 OpenDomain
-ID，不扫描正文、不推断 ID，不执行脚本，也不创建或提升 Candidate。Profile 和
-Sidecar Declaration 的正式机器契约位于 `schemas/`。
-
-Profile v1 尚不支持 grounding decision mapping，因此受信 Request Builder 会将
-请求归一化为 `unclassified`。当前应使用 advisory Assurance，或改用能够携带显式
-decision 的 integration；在契约扩展前，它不会通过 enforced Assurance。
-
-`assure` 与 `prepare` 的 grounding evidence 会告诉 Codex：
-
-- `Accepted grounding evidence` / `Read first`：先读哪些 accepted source files；
-- `Candidate boundaries`：显示各 Candidate 的 review status，均不能当作 accepted truth；
-- `Avoided semantic errors`：实现时要避免哪些业务语义错误。
-
-### 4. 不确定知识先写 Candidate
-
-AI 从代码、API、DB、测试或历史 Spec 里发现的新领域知识，默认写成 Domain Candidate：
-
-```yaml
----
-type: domain_candidate
-id: candidate-0001-order-lifecycle
-status: proposed
-proposed_change_type: update_lifecycle
-target:
-  type: lifecycle
-  id: sales.order-lifecycle
-confidence: medium
-extracted_by: codex
-extracted_at: 2026-07-07
-evidence:
-  - type: spec
-    location: examples/erp/opendomain/lifecycles/sales.order-lifecycle.md
-    summary: Accepted lifecycle does not include Closed state.
-    confidence: medium
-possible_conflicts:
-  - Existing accepted lifecycle does not include Closed.
-review:
-  state: proposed
-  suggested_reviewer: sales-domain-owner
----
-```
-
-Candidate 不是 accepted truth。它只是待人类审查的提案。
-
-## 常用命令
-
-| 目标 | 命令 |
-| --- | --- |
-| 查看帮助 | `opendomain help` |
-| 初始化 OpenDomain 与 Codex | `opendomain init --tools codex` |
-| 更新托管 Agent 适配 | `opendomain update` |
-| 检查 workspace 与 Agent 适配 | `opendomain doctor` |
-| 复制 ERP 示例 | `opendomain init --example erp` |
-| 验证全部 OpenDomain 文件 | `opendomain validate` |
-| 验证指定目录 | `opendomain validate examples/erp` |
-| 输出 JSON 验证结果 | `opendomain validate examples/erp --json` |
-| 为 Feature 准备 grounding | `opendomain prepare <feature-spec-or-dir>` |
-| 执行 advisory Assurance | `opendomain assure <source-unit>` |
-| 执行 enforced Assurance | `opendomain assure <source-unit> --mode enforced --json` |
-| 显式使用 OpenSpec integration | `opendomain prepare --integration openspec <feature-spec-or-dir>` |
-| 列出 integration | `opendomain integrations list` |
-| 验证 Integration Profile | `opendomain integrations validate` |
-| 显式使用本地 Profile | `opendomain prepare --profile <profile-id> <source-unit>` |
-| 列出 Candidate | `opendomain candidate list examples/erp` |
-| 查看 Candidate | `opendomain candidate show <candidate-id> examples/erp` |
-| 记录 Candidate review | `opendomain candidate review <candidate-id> --decision rejected --reviewed-by <name> --reason <text> examples/erp` |
-| 列出 ID | `opendomain ids list examples/erp` |
-| 检查引用 | `opendomain refs check examples/erp` |
-| 构建 index | `opendomain index build examples/erp --out /tmp/erp-index.json` |
-| 查询 ID | `opendomain index query sales.order --index /tmp/erp-index.json` |
-| 查询 context | `opendomain index query --context sales --index /tmp/erp-index.json` |
-| 运行 demo | `npm run demo` |
-| 运行测试 | `npm test` |
+OpenDomain 当前适合限定范围试点和公开迭代。稳定版之前格式与 CLI 仍可能变化，暂时
+不应成为生产关键领域决策的唯一治理来源。
 
 ## 公开资料
 
-- [English README](README.md)
+- [简体中文使用指南](USAGE.zh-CN.md)
+- [Agent 安装契约](INSTALL.md)
+- [ERP 示例](examples/erp/README.md)
 - [变更日志](CHANGELOG.md)
 - [贡献指南](CONTRIBUTING.md)
 - [安全策略](SECURITY.md)
-- `schemas/`：机器可读的正式格式契约
-- `examples/erp/`：不包含真实项目过程信息的合成互操作示例
+- `schemas/`：机器可读契约
 
-## 当前状态
+维护者规划记录属于私有过程资料，不会进入公开仓库或 npm 包。
+`examples/erp/` 下的 OpenSpec 只是合成互操作 fixture。
 
-OpenDomain 目前是 early alpha。
-
-已经可以用于：
-
-- 学习和试用 Git-native domain semantics；
-- 初始化一个项目的 OpenDomain 目录；
-- 运行 ERP 示例；
-- 验证 OpenDomain 文件格式；
-- 为 OpenSpec Feature 生成 grounding pack；
-- 用 advisory / enforced Assurance 区分准备状态与策略结果；
-- 用声明式 Profile 为其他结构化规划来源生成 grounding pack；
-- 用 index 生成 read-first plan；
-- 在本仓库中 dogfood OpenDomain 自身模型。
-
-暂时不建议直接用于生产治理的唯一来源。更合理的使用方式是先在一个业务子域中试点，让人类 reviewer 审查 accepted knowledge 和 Candidate 流程是否符合团队习惯。
-
-## 开源边界
-
-这个仓库只包含通用领域语义层、工具链、示例和 OpenDomain 自身模型。
-维护者的 OpenSpec、PRD、ADR、复盘、dogfooding 和发布过程记录不属于公开产品
-仓库，也不会包含在 npm 包中。
-
-请不要提交：
-
-- 公司内部流程；
-- 客户名称；
-- 生产凭证；
-- 私有业务规则；
-- 未脱敏的数据库结构；
-- 内部项目记忆；
-- 未经授权的业务文档或代码片段。
-
-如果你要在公司内部使用 OpenDomain，建议在私有仓库维护项目自己的 `opendomain/` 文件。
-
-## 贡献
-
-见 [CONTRIBUTING.md](CONTRIBUTING.md)。
-
-## 安全
-
-见 [SECURITY.md](SECURITY.md)。
-
-## 开源协议
-
-本项目采用 MIT 协议，见 [LICENSE](LICENSE)。
+OpenDomain 使用 [MIT License](LICENSE)。

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,308 @@
+# OpenDomain Usage Guide
+
+> Simplified Chinese: [USAGE.zh-CN.md](USAGE.zh-CN.md) | Project overview:
+> [README.md](README.md) | Agent installation contract: [INSTALL.md](INSTALL.md)
+
+This guide is for teams that want Codex to use OpenDomain as part of normal
+engineering work. You express the goal; Codex selects and executes the bounded
+OpenDomain workflow and shows its evidence.
+
+## Before You Start
+
+OpenDomain stores long-lived business semantics, not every fact in a software
+repository. Start with one real bounded context and a small set of concepts,
+rules, or lifecycles that materially constrain implementation.
+
+The responsibility boundary stays explicit:
+
+- You own the goal, business boundary, risk trade-offs, Candidate decisions,
+  and final acceptance.
+- Codex owns environment inspection, workflow selection, tool execution,
+  evidence separation, validation, and reporting.
+- Repository policy and tool approvals remain in force.
+- Inferred semantics start as Candidates. They are not accepted truth.
+
+## Ask Codex To Install OpenDomain
+
+From the repository root, say:
+
+> Install OpenDomain in this workspace. Follow the official Agent installation
+> contract, initialize the Codex integration, and prove that it is ready without
+> adding package metadata to this project.
+
+Codex should:
+
+1. Inspect the repository instructions and intended workspace root.
+2. Reuse a healthy `opendomain` CLI already on `PATH`, or install through a
+   compatible channel.
+3. Run initialization for a new integration or update an existing managed one.
+4. Run diagnostics and repository validation.
+5. Report the CLI version, installation path, files changed, and check results.
+6. Confirm that host `package.json` and lockfiles were not created or modified.
+
+The observable command sequence is:
+
+```bash
+opendomain --version
+opendomain init --tools codex --json
+opendomain doctor --json
+opendomain validate --json
+```
+
+For an existing configured integration, Codex uses:
+
+```bash
+opendomain update --json
+opendomain doctor --json
+opendomain validate --json
+```
+
+Initialization may generate Skills that the current Codex task cannot hot-load.
+The installing Agent must still finish the installation, diagnostics, and
+validation directly. Subsequent tasks discover the managed repository block and
+generated Skills automatically.
+
+## Installation Channels
+
+The [Agent Installation Contract](INSTALL.md) is authoritative for channel
+selection and safety.
+
+### npm alpha
+
+Prefer npm when Node.js 20 or Node.js 22 and newer is already available:
+
+```bash
+npm install --global @echopath-labs/opendomain@alpha
+opendomain --version
+```
+
+This is a global tool installation. Do not add OpenDomain to the host project's
+dependencies or scripts. Do not use `sudo npm install` by default.
+
+### Verified standalone executable
+
+Use the standalone fallback when a compatible npm environment is unavailable.
+Download the executable and `SHA256SUMS.txt` for the same version from
+[GitHub Releases](https://github.com/echopath-labs/openDomain/releases).
+
+| Target | Minimum system |
+| --- | --- |
+| `darwin-arm64` / `darwin-x64` | macOS 13.5 |
+| `linux-x64` | kernel 4.18, glibc 2.28, `GLIBCXX_3.4.25` |
+| `windows-x64.exe` | Windows 10 or Windows Server 2016 |
+
+Verify with `shasum -a 256` on macOS, `sha256sum` on Linux, or
+`Get-FileHash -Algorithm SHA256` in PowerShell. Install only into a user-owned
+directory on `PATH`. macOS binaries are currently ad-hoc signed but not
+notarized; Windows binaries are not Authenticode signed.
+
+Upgrade npm installations with the explicit alpha tag. Upgrade standalone
+installations by downloading, verifying, and replacing the executable. Then
+run:
+
+```bash
+opendomain update --json
+opendomain doctor --json
+opendomain validate --json
+```
+
+## What Initialization Changes
+
+The canonical workspace is `opendomain/`. During `0.x`, a legacy `domain/`
+workspace is a warned fallback only when the canonical root is absent. If both
+exist, `opendomain/` wins; OpenDomain never merges the roots.
+
+Codex initialization manages:
+
+- `opendomain/config.yaml` and the initial semantic directories;
+- one marked OpenDomain block in `AGENTS.md`;
+- `.codex/skills/opendomain-explore/SKILL.md`;
+- `.codex/skills/opendomain-model/SKILL.md`;
+- `.codex/skills/opendomain-review/SKILL.md`.
+
+Existing content outside the managed block remains user-owned. A conflicting
+user-owned Skill is reported rather than overwritten.
+
+## First Read-Only Domain Exploration
+
+Ask:
+
+> Explore the accepted business model for order cancellation. Do not modify
+> anything. Show the relevant concepts, rules, lifecycles, evidence, Candidate
+> boundaries, and model gaps.
+
+Codex should validate the workspace, find the smallest relevant accepted source
+set, read its evidence, and report Candidates separately. A useful result names:
+
+- accepted IDs and source files read;
+- durable rules or lifecycle constraints that affect the question;
+- Candidate IDs and their current review states;
+- missing, conflicting, or stale knowledge;
+- confirmation that no domain files were modified.
+
+## Brownfield Reverse Modeling
+
+An existing project can adopt OpenDomain before it has a complete model. Start
+with a read-only evidence pass:
+
+> Inspect this existing project's product documentation, behavior, tests, code,
+> APIs, and schemas. Do not modify anything yet. Propose the smallest useful
+> bounded context and list which conclusions are direct evidence versus
+> inference.
+
+After a human confirms the evidence boundary and initial accepted scope, ask:
+
+> Build the initial OpenDomain model for the agreed bounded context. Record
+> stable, evidenced semantics in the appropriate model, and put every uncertain,
+> inferred, or conflicting claim into a Candidate for human review.
+
+Code, APIs, database schema, and tests are evidence, not accepted domain meaning
+by themselves. Begin with one workflow that matters to implementation; do not
+attempt to reverse-model the entire system in one pass.
+
+If Assurance later reports `domain_model_gap`, Codex should explain which
+required semantics are missing and propose evidence-backed Candidate work. A
+model gap is an incomplete adoption state. Malformed declarations, broken IDs,
+and accepted/Candidate boundary violations are integrity failures and remain
+blocking.
+
+## Review A Candidate
+
+Ask:
+
+> Review candidate-0001. Show its target, evidence, confidence, possible
+> conflicts, and compatibility impact. Do not record a decision until I choose
+> one.
+
+Codex should inspect the Candidate and the accepted sources it may affect. The
+human then explicitly chooses `accepted`, `rejected`, `superseded`, or
+`deprecated`, together with reviewer identity and reason.
+
+Only after that decision may Codex run a mutation such as:
+
+```bash
+opendomain candidate review candidate-0001 --decision rejected --reviewed-by chase --reason "Conflicts with confirmed order policy"
+opendomain validate
+```
+
+An `accepted` Candidate review records that promotion is required; it does not
+silently rewrite accepted knowledge. Promotion remains a separately reviewed
+domain-model change.
+
+## Ground An Implementation Task
+
+Ask:
+
+> Implement this change. Before modifying behavior, classify whether long-lived
+> domain semantics are involved, run OpenDomain Assurance against the applicable
+> source unit, read every accepted source it lists, and report Candidate
+> boundaries separately.
+
+For an OpenSpec source unit, Codex commonly runs:
+
+```bash
+opendomain assure --integration openspec <source-unit>
+```
+
+Assurance separates the Grounding Request, preparation state, and policy
+outcome:
+
+| Grounding state | Meaning |
+| --- | --- |
+| `required` | The work is constrained by accepted domain semantics. |
+| `not_required` | Domain grounding is explicitly unnecessary and has a rationale. |
+| `unclassified` | Evidence is not yet sufficient to decide. |
+
+| Preparation | Advisory | Enforced |
+| --- | --- | --- |
+| `prepared` or valid `not_required` | pass | pass |
+| `domain_model_gap` or `unclassified` | warn | fail |
+| malformed input, contradiction, or broken reference | fail | fail |
+
+The completion report should name accepted IDs and source paths, Candidate
+boundaries, Assurance mode and outcome, and any unresolved model gap. Assurance
+evaluates current declarations and evidence; it does not prove Agent
+comprehension.
+
+## Use OpenSpec, Spec Kit, Or Another Planning Source
+
+OpenDomain is planning-tool-neutral:
+
+```text
+planning source
+  -> built-in adapter or declarative Integration Profile
+  -> Grounding Request
+  -> OpenDomain prepare / assure
+  -> Grounding Pack
+  -> Codex reads accepted evidence and Candidate boundaries
+```
+
+OpenSpec can declare `grounding` and `affects_domain` directly. The planning
+source owns the change intent and acceptance criteria; OpenDomain owns the
+referenced long-lived semantics.
+
+For another structured format, define a repository-local Profile under
+`opendomain/integrations/profiles/`, then inspect it with:
+
+```bash
+opendomain integrations validate
+opendomain integrations list
+opendomain prepare --profile <profile-id> <source-unit>
+opendomain assure --profile <profile-id> <source-unit>
+```
+
+Profiles normalize declared structured fields. They do not scan prose, execute
+extensions, infer IDs, create Candidates, or promote knowledge. Profile v1
+normalizes grounding to `unclassified`; use advisory Assurance unless the
+source integration carries an explicit decision.
+
+## Diagnose And Recover
+
+| Symptom | Action |
+| --- | --- |
+| `opendomain` is not found | Ask Codex to follow the installation contract and report its chosen user-owned install path. |
+| `doctor` reports missing or stale managed files | Inspect ownership conflicts, then run `update`; do not overwrite user-owned Skills. |
+| Both `opendomain/` and `domain/` exist | Use canonical `opendomain/`; migrate intentionally because roots are never merged. |
+| Assurance reports `domain_model_gap` | Review missing semantics and create evidence-backed Candidates incrementally. |
+| Enforced Assurance rejects `unclassified` | Classify the request with evidence or keep the workflow advisory while modeling. |
+| Profile selection is ambiguous | Select one Profile explicitly or narrow the Profile match declaration. |
+| Candidate is stale | Review, add evidence, reject, supersede, or deprecate it; do not treat age as acceptance. |
+
+Run these checks after repair:
+
+```bash
+opendomain doctor --json
+opendomain validate --json
+```
+
+## CLI Appendix
+
+Direct commands are useful for CI, diagnostics, and maintainers. Normal users
+can continue expressing intent to Codex.
+
+| Goal | Command |
+| --- | --- |
+| Initialize Codex integration | `opendomain init --tools codex` |
+| Synchronize managed resources | `opendomain update` |
+| Diagnose integration | `opendomain doctor` |
+| Validate current workspace | `opendomain validate` |
+| List accepted IDs | `opendomain ids list` |
+| Check references | `opendomain refs check` |
+| List Candidates | `opendomain candidate list` |
+| Inspect one Candidate | `opendomain candidate show <candidate-id>` |
+| Prepare a Grounding Pack | `opendomain prepare <source-unit>` |
+| Run advisory Assurance | `opendomain assure <source-unit>` |
+| Run enforced Assurance | `opendomain assure --mode enforced <source-unit> --json` |
+| Inspect Profiles | `opendomain integrations list` |
+| Validate Profiles | `opendomain integrations validate` |
+| Build a derived index | `opendomain index build` |
+| Query a domain ID | `opendomain index query <domain-id>` |
+
+## ERP Example
+
+The [ERP example](examples/erp/README.md) demonstrates one accepted order model,
+one Candidate, OpenSpec grounding, and a generic structured-source Profile. It
+is synthetic learning material, not a complete ERP ontology.
+
+Public project entrypoints: [README](README.md), [Contributing](CONTRIBUTING.md),
+[Security](SECURITY.md), and [Changelog](CHANGELOG.md).

--- a/USAGE.zh-CN.md
+++ b/USAGE.zh-CN.md
@@ -1,0 +1,280 @@
+# OpenDomain 使用指南
+
+> English: [USAGE.md](USAGE.md) | 项目简介: [README.zh-CN.md](README.zh-CN.md) |
+> Agent 安装契约: [INSTALL.md](INSTALL.md)
+
+本指南面向希望把 OpenDomain 嵌入日常 Codex 工作流的团队。你表达目标，Codex 在
+明确边界内选择并执行 OpenDomain 工作流，并提供可审查的证据。
+
+## 开始之前
+
+OpenDomain 保存长期业务语义，不是软件仓库里的所有事实。先选择一个真实 bounded
+context，以及少量会实际约束实现的概念、规则或生命周期。
+
+责任边界必须始终明确：
+
+- 你负责目标、业务边界、风险取舍、Candidate 决定和最终验收；
+- Codex 负责检查环境、选择路径、执行工具、区分证据状态、验证和报告；
+- 仓库规则和工具审批继续生效；
+- 推断语义先进入 Candidate，不能被当作 accepted truth。
+
+## 让 Codex 安装 OpenDomain
+
+在仓库根目录直接说：
+
+> 帮我在当前工作区安装 OpenDomain。遵循官方 Agent 安装契约，初始化 Codex
+> 集成并证明它已经可用，不要给这个项目添加 package metadata。
+
+Codex 应该：
+
+1. 检查仓库指令和目标 workspace root；
+2. 复用 `PATH` 上健康的 `opendomain` CLI，或选择兼容渠道安装；
+3. 为新集成执行初始化，为已有受管集成执行更新；
+4. 运行诊断和仓库验证；
+5. 报告 CLI 版本、安装路径、变更文件和检查结果；
+6. 确认宿主 `package.json` 与 lockfile 没有被创建或修改。
+
+可观察的命令序列是：
+
+```bash
+opendomain --version
+opendomain init --tools codex --json
+opendomain doctor --json
+opendomain validate --json
+```
+
+对于已经配置好的集成，Codex 使用：
+
+```bash
+opendomain update --json
+opendomain doctor --json
+opendomain validate --json
+```
+
+初始化生成的 Skills 可能无法被当前 Codex 任务热加载。负责安装的 Agent 仍必须直接
+完成本轮安装、诊断和验证；后续任务会自动发现受管仓库区块和生成的 Skills。
+
+## 安装渠道
+
+[Agent 安装契约](INSTALL.md)是渠道选择和安全边界的正式依据。
+
+### npm alpha
+
+已经有 Node.js 20，或 Node.js 22 及以上环境时优先使用 npm：
+
+```bash
+npm install --global @echopath-labs/opendomain@alpha
+opendomain --version
+```
+
+这是全局工具安装，不要把 OpenDomain 加进宿主项目依赖或 scripts，也不要默认使用
+`sudo npm install`。
+
+### 已校验的独立二进制
+
+没有兼容 npm 环境时使用独立二进制。从 [GitHub Releases](https://github.com/echopath-labs/openDomain/releases)
+下载同一版本的 executable 和 `SHA256SUMS.txt`。
+
+| Target | 最低系统 |
+| --- | --- |
+| `darwin-arm64` / `darwin-x64` | macOS 13.5 |
+| `linux-x64` | kernel 4.18、glibc 2.28、`GLIBCXX_3.4.25` |
+| `windows-x64.exe` | Windows 10 或 Windows Server 2016 |
+
+macOS 使用 `shasum -a 256`，Linux 使用 `sha256sum`，PowerShell 使用
+`Get-FileHash -Algorithm SHA256`。只安装到 `PATH` 上用户拥有的目录。当前 macOS
+二进制采用 ad-hoc 签名但未 notarize，Windows 二进制没有 Authenticode 签名。
+
+npm 使用显式 alpha tag 升级；独立二进制需要下载、校验并替换 executable。升级后
+运行：
+
+```bash
+opendomain update --json
+opendomain doctor --json
+opendomain validate --json
+```
+
+## 初始化会改变什么
+
+Canonical workspace 是 `opendomain/`。在 `0.x` 期间，只有 canonical root 不存在
+时才会带警告读取 legacy `domain/`。如果两个目录都存在，`opendomain/` 生效，
+OpenDomain 永远不会合并两棵目录。
+
+Codex 初始化会管理：
+
+- `opendomain/config.yaml` 和初始语义目录；
+- `AGENTS.md` 中一个带 marker 的 OpenDomain 区块；
+- `.codex/skills/opendomain-explore/SKILL.md`；
+- `.codex/skills/opendomain-model/SKILL.md`；
+- `.codex/skills/opendomain-review/SKILL.md`。
+
+受管区块外的既有内容仍由用户拥有。遇到同名用户 Skill 时，OpenDomain 会报告冲突，
+不会覆盖。
+
+## 第一次只读了解业务
+
+可以说：
+
+> 只读了解订单取消相关的 accepted 业务模型，不要修改任何内容。列出相关概念、
+> 规则、生命周期、证据、Candidate boundaries 和模型缺口。
+
+Codex 应先验证 workspace，找到最小的相关 accepted source 集合，读取证据，并把
+Candidate 分开报告。结果至少应该包含：
+
+- 读取过的 accepted IDs 与 source files；
+- 会影响当前问题的长期规则或生命周期约束；
+- Candidate IDs 及当前 review state；
+- 缺失、冲突或陈旧知识；
+- 没有修改领域文件的确认。
+
+## 既有项目逆向建模
+
+既有项目不需要先完成完整模型才能使用 OpenDomain。先执行只读证据调查：
+
+> 检查这个既有项目的产品文档、实际行为、测试、代码、API 和 Schema，暂时不要
+> 修改。提出最小可用 bounded context，并区分哪些结论是直接证据、哪些是推断。
+
+由人确认调查边界和初始 accepted scope 后再说：
+
+> 为已经确认的 bounded context 建立第一版 OpenDomain 模型。稳定且有证据的语义
+> 写入适当模型，所有不确定、推断或冲突判断先写成 Candidate 等待人工审查。
+
+代码、API、数据库 Schema 和测试只是证据，不会自动成为 accepted domain meaning。
+先选择一个真正影响实现的工作流，不要一次逆向整个系统。
+
+后续 Assurance 如果报告 `domain_model_gap`，Codex 应说明缺少哪些必要语义，并提出
+有证据的 Candidate 工作。这代表采用尚不完整；格式错误、断裂 ID、accepted 与
+Candidate 边界冲突则属于完整性失败，仍然必须阻断。
+
+## 审查 Candidate
+
+可以说：
+
+> 审查 candidate-0001，列出 target、evidence、confidence、可能冲突和兼容性影响。
+> 在我明确选择之前，不要记录决定。
+
+Codex 应读取 Candidate 和它可能影响的 accepted source。然后由人明确选择
+`accepted`、`rejected`、`superseded` 或 `deprecated`，并提供 reviewer 和 reason。
+
+只有在获得决定后，Codex 才可以执行类似变更：
+
+```bash
+opendomain candidate review candidate-0001 --decision rejected --reviewed-by chase --reason "Conflicts with confirmed order policy"
+opendomain validate
+```
+
+`accepted` Candidate review 只会记录需要 promotion，不会静默改写 accepted
+knowledge。Promotion 仍是一次单独审查的领域模型变更。
+
+## 为实现任务准备 Grounding
+
+可以说：
+
+> 实现这个变更。修改行为前先判断是否涉及长期领域语义，对适用 Source Unit 运行
+> OpenDomain Assurance，读取列出的全部 accepted sources，并单独报告 Candidate
+> boundaries。
+
+对于 OpenSpec Source Unit，Codex 通常执行：
+
+```bash
+opendomain assure --integration openspec <source-unit>
+```
+
+Assurance 会分开报告 Grounding Request、准备状态和策略结果：
+
+| Grounding 状态 | 含义 |
+| --- | --- |
+| `required` | 本次工作受 accepted domain semantics 约束 |
+| `not_required` | 明确不需要 grounding，并提供了 rationale |
+| `unclassified` | 当前证据不足以判断 |
+
+| Preparation | Advisory | Enforced |
+| --- | --- | --- |
+| `prepared` 或合法 `not_required` | pass | pass |
+| `domain_model_gap` 或 `unclassified` | warn | fail |
+| 非法输入、矛盾或断裂引用 | fail | fail |
+
+完成报告应包含 accepted IDs 与 source paths、Candidate boundaries、Assurance mode
+和 outcome，以及未解决 model gap。Assurance 评估的是当前声明和证据，不能证明
+Agent 已经理解模型。
+
+## 与 OpenSpec、Spec Kit 或其他规划来源配合
+
+OpenDomain 不绑定某个规划工具：
+
+```text
+planning source
+  -> built-in adapter 或声明式 Integration Profile
+  -> Grounding Request
+  -> OpenDomain prepare / assure
+  -> Grounding Pack
+  -> Codex 读取 accepted evidence 与 Candidate boundaries
+```
+
+OpenSpec 可以直接声明 `grounding` 和 `affects_domain`。规划来源继续拥有变更意图和
+验收标准；OpenDomain 拥有被引用的长期语义。
+
+其他结构化格式可以在 `opendomain/integrations/profiles/` 下定义 repository-local
+Profile，然后检查：
+
+```bash
+opendomain integrations validate
+opendomain integrations list
+opendomain prepare --profile <profile-id> <source-unit>
+opendomain assure --profile <profile-id> <source-unit>
+```
+
+Profile 只归一化已声明的结构化字段，不扫描正文、不执行扩展、不推断 ID、不创建
+Candidate，也不提升 knowledge。Profile v1 会把 grounding 归一化为
+`unclassified`；除非 source integration 能提供显式 decision，否则使用 advisory
+Assurance。
+
+## 诊断与恢复
+
+| 现象 | 处理方式 |
+| --- | --- |
+| 找不到 `opendomain` | 让 Codex 按安装契约安装，并报告选定的用户安装路径 |
+| `doctor` 报告受管文件缺失或陈旧 | 检查 ownership conflict 后运行 `update`，不要覆盖用户 Skill |
+| `opendomain/` 与 `domain/` 同时存在 | 使用 canonical `opendomain/` 并有计划迁移，因为两棵目录不会合并 |
+| Assurance 报告 `domain_model_gap` | 审查缺失语义，逐步创建有证据的 Candidate |
+| Enforced Assurance 拒绝 `unclassified` | 用证据完成分类，或在建模期间保持 advisory |
+| Profile 匹配不唯一 | 显式选择一个 Profile，或缩小 match declaration |
+| Candidate 已陈旧 | 审查、增加证据、拒绝、supersede 或 deprecate；不能把时间当作接受 |
+
+修复后运行：
+
+```bash
+opendomain doctor --json
+opendomain validate --json
+```
+
+## CLI 附录
+
+直接命令适合 CI、诊断和维护者。正常用户可以继续向 Codex 表达意图。
+
+| 目标 | 命令 |
+| --- | --- |
+| 初始化 Codex 集成 | `opendomain init --tools codex` |
+| 同步受管资源 | `opendomain update` |
+| 诊断集成 | `opendomain doctor` |
+| 验证当前 workspace | `opendomain validate` |
+| 列出 accepted IDs | `opendomain ids list` |
+| 检查引用 | `opendomain refs check` |
+| 列出 Candidate | `opendomain candidate list` |
+| 查看 Candidate | `opendomain candidate show <candidate-id>` |
+| 准备 Grounding Pack | `opendomain prepare <source-unit>` |
+| 执行 advisory Assurance | `opendomain assure <source-unit>` |
+| 执行 enforced Assurance | `opendomain assure --mode enforced <source-unit> --json` |
+| 查看 Profile | `opendomain integrations list` |
+| 验证 Profile | `opendomain integrations validate` |
+| 构建派生 index | `opendomain index build` |
+| 查询 domain ID | `opendomain index query <domain-id>` |
+
+## ERP 示例
+
+[ERP 示例](examples/erp/README.md)展示一个 accepted order 模型、一个 Candidate、
+OpenSpec grounding 和一个通用 structured-source Profile。它是合成学习材料，不是
+完整 ERP ontology。
+
+公开项目入口：[README](README.zh-CN.md)、[贡献指南](CONTRIBUTING.md)、
+[安全策略](SECURITY.md)和[变更日志](CHANGELOG.md)。

--- a/examples/erp/README.md
+++ b/examples/erp/README.md
@@ -1,5 +1,10 @@
 # ERP Example
 
+Start with the [English Usage Guide](../../USAGE.md) or
+[Simplified Chinese Usage Guide](../../USAGE.zh-CN.md) for the complete
+Agent-driven workflow. Return to the project [README](../../README.md) for the
+product boundary and installation entrypoint.
+
 This example demonstrates the smallest useful OpenDomain shape:
 
 - one bounded context

--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
     "INSTALL.md",
     "README.md",
     "README.zh-CN.md",
+    "USAGE.md",
+    "USAGE.zh-CN.md",
+    "CONTRIBUTING.md",
+    "SECURITY.md",
     "LICENSE",
     "CHANGELOG.md"
   ],

--- a/scripts/smoke-installed-package.mjs
+++ b/scripts/smoke-installed-package.mjs
@@ -62,7 +62,26 @@ try {
   await access(path.join(installedRoot, "schemas", "domain-declaration.schema.json"));
   await access(path.join(installedRoot, "schemas", "assurance-result.schema.json"));
   await access(path.join(installedRoot, "schemas", "workspace-config.schema.json"));
-  await access(path.join(installedRoot, "INSTALL.md"));
+  for (const publicDocument of [
+    "README.md",
+    "README.zh-CN.md",
+    "USAGE.md",
+    "USAGE.zh-CN.md",
+    "INSTALL.md",
+    "CONTRIBUTING.md",
+    "SECURITY.md",
+    "CHANGELOG.md",
+    "LICENSE",
+    "examples/erp/README.md"
+  ]) {
+    await access(path.join(installedRoot, ...publicDocument.split("/")));
+  }
+  for (const privatePath of ["openspec", "docs", ".codex"]) {
+    await assert.rejects(
+      access(path.join(installedRoot, privatePath)),
+      (error) => error?.code === "ENOENT"
+    );
+  }
   await access(path.join(installedRoot, "scripts", "smoke-installed-package.mjs"));
   for (const maintainerScript of [
     "assemble-standalone-assets.mjs",

--- a/tests/public-docs.test.mjs
+++ b/tests/public-docs.test.mjs
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import { execFile as execFileCallback } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const execFile = promisify(execFileCallback);
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+);
+
+const publicDocuments = [
+  "README.md",
+  "README.zh-CN.md",
+  "USAGE.md",
+  "USAGE.zh-CN.md",
+  "INSTALL.md",
+  "CONTRIBUTING.md",
+  "SECURITY.md",
+  "CHANGELOG.md",
+  "examples/erp/README.md"
+];
+
+const pairedNavigation = new Map([
+  ["README.md", ["README.zh-CN.md", "USAGE.md", "INSTALL.md"]],
+  ["README.zh-CN.md", ["README.md", "USAGE.zh-CN.md", "INSTALL.md"]],
+  ["USAGE.md", ["USAGE.zh-CN.md", "README.md", "INSTALL.md", "examples/erp/README.md"]],
+  ["USAGE.zh-CN.md", ["USAGE.md", "README.zh-CN.md", "INSTALL.md", "examples/erp/README.md"]]
+]);
+
+test("public guidance exposes paired Agent adoption entrypoints", async () => {
+  for (const document of publicDocuments) {
+    const details = await stat(path.join(repositoryRoot, document));
+    assert.equal(details.isFile(), true, `${document} must be a public file`);
+  }
+
+  for (const [document, expectedTargets] of pairedNavigation) {
+    const content = await readDocument(document);
+    const targets = new Set(extractMarkdownLinks(content).map(({ target }) => {
+      return normalizeLinkTarget(target, document).file;
+    }));
+
+    for (const expectedTarget of expectedTargets) {
+      assert.ok(
+        targets.has(expectedTarget),
+        `${document} must link to ${expectedTarget}`
+      );
+    }
+  }
+});
+
+test("public Markdown links resolve without private process records", async () => {
+  for (const document of publicDocuments) {
+    const content = await readDocument(document);
+    for (const { target, line } of extractMarkdownLinks(content)) {
+      if (isExternalLink(target)) {
+        continue;
+      }
+
+      const resolved = normalizeLinkTarget(target, document);
+      assert.doesNotMatch(
+        resolved.file,
+        /^(?:docs|openspec)(?:\/|$)/,
+        `${document}:${line} links to a private process path`
+      );
+
+      const details = await stat(path.join(repositoryRoot, resolved.file));
+      assert.equal(
+        details.isFile(),
+        true,
+        `${document}:${line} target is not a file: ${resolved.file}`
+      );
+
+      if (resolved.anchor) {
+        const targetContent = await readDocument(resolved.file);
+        assert.ok(
+          markdownAnchors(targetContent).has(resolved.anchor),
+          `${document}:${line} has an unknown anchor: ${target}`
+        );
+      }
+    }
+  }
+});
+
+test("documented OpenDomain commands belong to the current CLI", async () => {
+  const cli = path.join(repositoryRoot, "bin", "opendomain.mjs");
+  const { stdout } = await execFile(process.execPath, [cli, "--help"], {
+    cwd: repositoryRoot,
+    encoding: "utf8"
+  });
+  const supportedCommands = new Set(extractOpenDomainCommands(stdout).map(commandSignature));
+
+  for (const document of publicDocuments) {
+    const content = await readDocument(document);
+    for (const command of extractOpenDomainCommands(content)) {
+      const signature = commandSignature(command);
+      assert.ok(
+        supportedCommands.has(signature),
+        `${document} documents an unsupported command: ${command}`
+      );
+    }
+  }
+});
+
+async function readDocument(relativePath) {
+  return readFile(path.join(repositoryRoot, relativePath), "utf8");
+}
+
+function extractMarkdownLinks(content) {
+  const links = [];
+  const pattern = /!?(?:\[[^\]]*\])\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+  let match;
+
+  while ((match = pattern.exec(content)) !== null) {
+    links.push({
+      target: match[1],
+      line: content.slice(0, match.index).split("\n").length
+    });
+  }
+
+  return links;
+}
+
+function isExternalLink(target) {
+  return /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(target);
+}
+
+function normalizeLinkTarget(target, sourceDocument) {
+  const [rawFile, rawAnchor = ""] = target.split("#", 2);
+  const sourceDirectory = path.posix.dirname(sourceDocument);
+  const decodedFile = decodeURIComponent(rawFile || path.posix.basename(sourceDocument));
+  const file = path.posix.normalize(path.posix.join(sourceDirectory, decodedFile));
+
+  assert.notEqual(file, "..", `${sourceDocument} link escapes the repository`);
+  assert.equal(
+    file.startsWith("../"),
+    false,
+    `${sourceDocument} link escapes the repository: ${target}`
+  );
+
+  return {
+    file,
+    anchor: decodeURIComponent(rawAnchor).toLowerCase()
+  };
+}
+
+function markdownAnchors(content) {
+  const counts = new Map();
+  const anchors = new Set();
+
+  for (const line of content.split("\n")) {
+    const match = /^(#{1,6})\s+(.+?)\s*#*\s*$/.exec(line);
+    if (!match) {
+      continue;
+    }
+
+    const base = match[2]
+      .trim()
+      .toLowerCase()
+      .replace(/<[^>]+>/g, "")
+      .replace(/[^\p{L}\p{N}\s-]/gu, "")
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-");
+    const count = counts.get(base) ?? 0;
+    counts.set(base, count + 1);
+    anchors.add(count === 0 ? base : `${base}-${count}`);
+  }
+
+  return anchors;
+}
+
+function extractOpenDomainCommands(content) {
+  return content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("opendomain "))
+    .map((line) => line.replace(/^opendomain\s+/, "").trim());
+}
+
+function commandSignature(command) {
+  const words = command.split(/\s+/).filter((word) => !word.startsWith("--"));
+  if (command.startsWith("--version") || command.startsWith("-v")) {
+    return "--version";
+  }
+
+  const first = words[0];
+  if (["candidate", "index", "integrations", "ids", "refs", "demo"].includes(first)) {
+    return `${first} ${words[1]}`;
+  }
+  return first;
+}


### PR DESCRIPTION
## Summary
- make natural-language Codex installation and follow-up prompts the primary README path
- add complete English and Simplified Chinese Usage Guides for greenfield, Brownfield, Candidate review, grounding, integrations, and recovery
- verify public links, CLI consistency, npm package contents, and private process-record exclusion

## Validation
- npm test (181 passed)
- node --test tests/public-docs.test.mjs (3 passed)
- npm run smoke:agent-bootstrap
- npm run smoke:package
- npm pack --dry-run --json --cache /tmp/opendomain-npm-cache (64 entries)
- npm run opendomain -- validate (26 documents, one pre-existing stale Candidate warning)
- openspec validate --all --json (13/13 passed in the private process repository)

This change does not modify runtime behavior, schemas, accepted domain semantics, npm versions, tags, or releases. Private OpenSpec and development records are not included.