### PR TITLE
docs: link GitHub and npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # OpenDomain
 
 [![CI](https://github.com/echopath-labs/openDomain/actions/workflows/ci.yml/badge.svg)](https://github.com/echopath-labs/openDomain/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/%40echopath-labs%2Fopendomain/alpha?label=npm)](https://www.npmjs.com/package/@echopath-labs/opendomain)
 ![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)
 ![Status](https://img.shields.io/badge/status-alpha-f59e0b.svg)
 ![Node](https://img.shields.io/badge/node-%3E%3D20-0f766e.svg)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,7 @@
 # OpenDomain
 
 [![CI](https://github.com/echopath-labs/openDomain/actions/workflows/ci.yml/badge.svg)](https://github.com/echopath-labs/openDomain/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/%40echopath-labs%2Fopendomain/alpha?label=npm)](https://www.npmjs.com/package/@echopath-labs/opendomain)
 ![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)
 ![Status](https://img.shields.io/badge/status-alpha-f59e0b.svg)
 ![Node](https://img.shields.io/badge/node-%3E%3D20-0f766e.svg)

--- a/tests/public-docs.test.mjs
+++ b/tests/public-docs.test.mjs
@@ -32,6 +32,11 @@ const pairedNavigation = new Map([
   ["USAGE.zh-CN.md", ["USAGE.md", "README.zh-CN.md", "INSTALL.md", "examples/erp/README.md"]]
 ]);
 
+const npmPackageUrl =
+  "https://www.npmjs.com/package/@echopath-labs/opendomain";
+const npmAlphaBadgeUrl =
+  "https://img.shields.io/npm/v/%40echopath-labs%2Fopendomain/alpha?label=npm";
+
 test("public guidance exposes paired Agent adoption entrypoints", async () => {
   for (const document of publicDocuments) {
     const details = await stat(path.join(repositoryRoot, document));
@@ -50,6 +55,19 @@ test("public guidance exposes paired Agent adoption entrypoints", async () => {
         `${document} must link to ${expectedTarget}`
       );
     }
+  }
+});
+
+test("public READMEs expose the same alpha-aware npm package entrypoint", async () => {
+  const expectedBadge = `[![npm](${npmAlphaBadgeUrl})](${npmPackageUrl})`;
+
+  for (const document of ["README.md", "README.zh-CN.md"]) {
+    const content = await readDocument(document);
+    assert.equal(
+      content.split(expectedBadge).length - 1,
+      1,
+      `${document} must contain exactly one linked npm alpha badge`
+    );
   }
 });
 


### PR DESCRIPTION
## Summary
- add the alpha-aware npm package badge to both public READMEs
- lock README parity and the alpha dist-tag in the public documentation test
- pair the README change with the GitHub About Website pointing to the official npm package

## Validation
- node --test tests/public-docs.test.mjs (4 passed)
- npm test (182 passed)
- npm run opendomain -- validate (26 documents, existing stale Candidate warning only)
- openspec validate --all --json (14/14)
- git diff --check