### PR TITLE
chore: prepare OpenDomain 0.1.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 _No unreleased changes._
 
+## 0.1.0-rc.1 - 2026-08-13
+
+- Adopt the Apache License 2.0 for OpenDomain releases starting with rc.1,
+  including aligned package metadata, public documentation, and NOTICE material.
+- Preserve alpha.10 and all earlier immutable releases under the licenses with
+  which they were originally distributed; this change is forward-only.
+- Freeze the intended `0.1.0` compatibility surface for the published source
+  schemas, Grounding Protocol v1, Core API 1.0, context-export v1, existing CLI
+  and workspace behavior, and package-neutral npm/standalone installation.
+- Add explicit `@rc` installation guidance and keep the release candidate away
+  from npm `latest`; stable publication remains a separately approved operation.
+- Record real maintainer-owned project adoption and a bounded human Candidate
+  judgement while retaining the reviewed Candidate as Proposed and
+  non-authoritative; no accepted knowledge is promoted by this release source.
+
 ## 0.1.0-alpha.10 - 2026-08-11
 
 - Add multi-product governance manifests, exposure propagation, dependency-cycle and forbidden-dependency checks,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,12 @@
 # Contributing to OpenDomain
 
-OpenDomain is an early alpha project. Contributions should keep the core small,
-Git-native, evidence-backed, and easy for AI agents to consume.
+OpenDomain is preparing its first stable release. Contributions should keep the
+core small, Git-native, evidence-backed, and easy for AI agents to consume.
+
+Unless explicitly stated otherwise, contributions submitted for inclusion in
+OpenDomain are licensed under the Apache License 2.0 beginning with
+`0.1.0-rc.1`. Contributors must have the right to submit their work under
+that license.
 
 ## Development Setup
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,18 +29,22 @@ First run `opendomain --version` if `opendomain` is already on `PATH`. A usable
 existing CLI does not need to be installed again; continue with workspace
 initialization or update below.
 
-### npm Alpha Channel
+### npm Release Candidate Channel
 
 Prefer npm when a supported Node.js and npm tool environment is already
 available. OpenDomain currently supports Node.js 20 or Node.js 22 and newer;
 Node.js 21 is not supported.
 
-During the prerelease period, always name the alpha distribution tag:
+During the release-candidate rehearsal, always name the `rc` distribution tag:
 
 ```bash
-npm install --global @echopath-labs/opendomain@alpha
+npm install --global @echopath-labs/opendomain@rc
 opendomain --version
 ```
+
+The RC tag does not move npm `latest`. Use `@rc` only when deliberately testing
+the first-stable compatibility candidate; normal stable installation remains a
+separately published and verified channel.
 
 This is a global tool installation. Do not run `npm install` without
 `--global` from the user's project. If the configured global prefix is not

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 Chase
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+OpenDomain
+Copyright 2026 EchoPath Labs
+
+This product includes software developed by EchoPath Labs contributors.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # OpenDomain
 
 [![CI](https://github.com/echopath-labs/openDomain/actions/workflows/ci.yml/badge.svg)](https://github.com/echopath-labs/openDomain/actions/workflows/ci.yml)
-[![npm](https://img.shields.io/npm/v/%40echopath-labs%2Fopendomain/alpha?label=npm)](https://www.npmjs.com/package/@echopath-labs/opendomain)
-![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)
-![Status](https://img.shields.io/badge/status-alpha-f59e0b.svg)
+[![npm](https://img.shields.io/npm/v/%40echopath-labs%2Fopendomain/rc?label=npm%20rc)](https://www.npmjs.com/package/@echopath-labs/opendomain)
+![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-green.svg)
+![Status](https://img.shields.io/badge/status-release%20candidate-f59e0b.svg)
 ![Node](https://img.shields.io/badge/node-%3E%3D20-0f766e.svg)
 ![Source](https://img.shields.io/badge/source-Markdown%20%2B%20YAML-2563eb.svg)
 
@@ -108,19 +108,20 @@ Git versioning.
 Most users should ask Codex to install OpenDomain. The same channels are
 available manually.
 
-### npm alpha channel
+### npm release candidate channel
 
 Use npm when Node.js 20 or Node.js 22 and newer is already available:
 
 ```bash
-npm install --global @echopath-labs/opendomain@alpha
+npm install --global @echopath-labs/opendomain@rc
 opendomain --version
 opendomain init --tools codex
 opendomain doctor
 opendomain validate
 ```
 
-The explicit `@alpha` tag is required during prerelease development.
+The explicit `@rc` tag is required for release-candidate evaluation and does
+not move npm `latest`.
 
 ### Standalone binary
 
@@ -141,7 +142,7 @@ for verification and upgrade steps.
 
 ## Current Capabilities
 
-The current alpha includes:
+The current release candidate includes:
 
 - Markdown with YAML front matter as the source of truth;
 - schema validation and reference integrity checks;
@@ -155,9 +156,14 @@ The current alpha includes:
 - managed Codex instructions, Skills, updates, and diagnostics;
 - npm and standalone CLI distribution without host package metadata.
 
-OpenDomain is suitable for bounded trials and public iteration. The format and
-CLI may still change before a stable release, and it should not yet be the sole
-governance source for production-critical domain decisions.
+OpenDomain rc.1 is the compatibility rehearsal for `0.1.0`. It freezes the
+published Markdown/YAML source schemas, Grounding Protocol v1, Core API 1.0,
+context-export v1, existing CLI commands and exit semantics, workspace
+resolution, and package-neutral npm/standalone behavior used by current
+maintainer-owned adopters. A discovered incompatibility defers stable release
+or requires reviewed migration guidance. This evidence does not replace each
+organization's production governance, security review, or human Candidate
+decisions, and independent external-customer validation remains deferred.
 
 For a multi-product canonical workspace, add a versioned
 `opendomain/governance.yaml` and place each domain group's normal semantic
@@ -189,4 +195,6 @@ Maintainer planning records are private process material and are not shipped in
 the public repository or npm package. The OpenSpec fixture under `examples/erp/`
 is synthetic interoperability data.
 
-OpenDomain is licensed under the [MIT License](LICENSE).
+OpenDomain is licensed under the [Apache License 2.0](LICENSE) starting with
+`0.1.0-rc.1`. Published `0.1.0-alpha.10` and earlier artifacts retain their
+original license identities. See [NOTICE](NOTICE) for attribution information.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,9 +1,9 @@
 # OpenDomain
 
 [![CI](https://github.com/echopath-labs/openDomain/actions/workflows/ci.yml/badge.svg)](https://github.com/echopath-labs/openDomain/actions/workflows/ci.yml)
-[![npm](https://img.shields.io/npm/v/%40echopath-labs%2Fopendomain/alpha?label=npm)](https://www.npmjs.com/package/@echopath-labs/opendomain)
-![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)
-![Status](https://img.shields.io/badge/status-alpha-f59e0b.svg)
+[![npm](https://img.shields.io/npm/v/%40echopath-labs%2Fopendomain/rc?label=npm%20rc)](https://www.npmjs.com/package/@echopath-labs/opendomain)
+![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-green.svg)
+![Status](https://img.shields.io/badge/status-release%20candidate-f59e0b.svg)
 ![Node](https://img.shields.io/badge/node-%3E%3D20-0f766e.svg)
 ![Source](https://img.shields.io/badge/source-Markdown%20%2B%20YAML-2563eb.svg)
 
@@ -99,19 +99,19 @@ AGENTS.md                              受管 OpenDomain 区块
 
 大多数用户只需要让 Codex 安装。也可以手动使用相同渠道。
 
-### npm alpha 渠道
+### npm RC 渠道
 
 已有 Node.js 20，或 Node.js 22 及以上环境时使用 npm：
 
 ```bash
-npm install --global @echopath-labs/opendomain@alpha
+npm install --global @echopath-labs/opendomain@rc
 opendomain --version
 opendomain init --tools codex
 opendomain doctor
 opendomain validate
 ```
 
-预发布阶段必须显式使用 `@alpha`。
+评估 release candidate 时必须显式使用 `@rc`；该渠道不会移动 npm `latest`。
 
 ### 独立二进制
 
@@ -130,7 +130,7 @@ opendomain validate
 
 ## 当前能力
 
-当前 alpha 已包含：
+当前 release candidate 已包含：
 
 - Markdown + YAML front matter source of truth；
 - Schema 校验与引用完整性检查；
@@ -144,8 +144,11 @@ opendomain validate
 - 受管 Codex 指令、Skills、更新和诊断；
 - 不引入宿主 package metadata 的 npm 与独立 CLI 分发。
 
-OpenDomain 当前适合限定范围试点和公开迭代。稳定版之前格式与 CLI 仍可能变化，暂时
-不应成为生产关键领域决策的唯一治理来源。
+OpenDomain rc.1 是 `0.1.0` 的兼容性演练，冻结已发布的 Markdown/YAML source schemas、
+Grounding Protocol v1、Core API 1.0、context-export v1、现有 CLI 命令与退出语义、
+workspace resolution，以及现有维护者项目使用的 package-neutral npm/standalone 行为。
+发现不兼容行为时必须延期 stable 或提供经过审查的迁移说明。本证据不能替代组织自身
+的生产治理、安全审查与人工 Candidate 决策；独立外部客户验证仍是明确延期项。
 
 多产品 canonical workspace 可以增加版本化的 `opendomain/governance.yaml`，并把每个
 domain group 的普通语义目录放入声明的 `source_root`。`opendomain validate --json`
@@ -173,4 +176,5 @@ release。详见[嵌入 Core 与导出 Context](USAGE.zh-CN.md#嵌入-core-与�
 维护者规划记录属于私有过程资料，不会进入公开仓库或 npm 包。
 `examples/erp/` 下的 OpenSpec 只是合成互操作 fixture。
 
-OpenDomain 使用 [MIT License](LICENSE)。
+OpenDomain 从 `0.1.0-rc.1` 开始采用 [Apache License 2.0](LICENSE)。已经发布的
+`0.1.0-alpha.10` 及更早 artifacts 保持其原始许可身份；归属信息见 [NOTICE](NOTICE)。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,7 @@
 # Security Policy
 
-OpenDomain is currently early alpha.
+OpenDomain is currently a release candidate preparing for its first stable
+release.
 
 ## Reporting a Vulnerability
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -67,12 +67,12 @@ generated Skills automatically.
 The [Agent Installation Contract](INSTALL.md) is authoritative for channel
 selection and safety.
 
-### npm alpha
+### npm release candidate
 
 Prefer npm when Node.js 20 or Node.js 22 and newer is already available:
 
 ```bash
-npm install --global @echopath-labs/opendomain@alpha
+npm install --global @echopath-labs/opendomain@rc
 opendomain --version
 ```
 
@@ -96,9 +96,10 @@ Verify with `shasum -a 256` on macOS, `sha256sum` on Linux, or
 directory on `PATH`. macOS binaries are currently ad-hoc signed but not
 notarized; Windows binaries are not Authenticode signed.
 
-Upgrade npm installations with the explicit alpha tag. Upgrade standalone
-installations by downloading, verifying, and replacing the executable. Then
-run:
+The `@rc` channel is an explicit first-stable rehearsal and does not move npm
+`latest`. Upgrade npm release-candidate installations with the explicit rc tag.
+Upgrade standalone installations by downloading, verifying, and replacing the
+executable. Then run:
 
 ```bash
 opendomain update --json

--- a/USAGE.zh-CN.md
+++ b/USAGE.zh-CN.md
@@ -58,12 +58,12 @@ opendomain validate --json
 
 [Agent 安装契约](INSTALL.md)是渠道选择和安全边界的正式依据。
 
-### npm alpha
+### npm RC
 
 已经有 Node.js 20，或 Node.js 22 及以上环境时优先使用 npm：
 
 ```bash
-npm install --global @echopath-labs/opendomain@alpha
+npm install --global @echopath-labs/opendomain@rc
 opendomain --version
 ```
 
@@ -85,7 +85,8 @@ macOS 使用 `shasum -a 256`，Linux 使用 `sha256sum`，PowerShell 使用
 `Get-FileHash -Algorithm SHA256`。只安装到 `PATH` 上用户拥有的目录。当前 macOS
 二进制采用 ad-hoc 签名但未 notarize，Windows 二进制没有 Authenticode 签名。
 
-npm 使用显式 alpha tag 升级；独立二进制需要下载、校验并替换 executable。升级后
+`@rc` 是显式的首个 stable 演练渠道，不会移动 npm `latest`。RC 安装使用显式 rc tag
+升级；独立二进制需要下载、校验并替换 executable。升级后
 运行：
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@echopath-labs/opendomain",
-  "version": "0.1.0-alpha.10",
+  "version": "0.1.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@echopath-labs/opendomain",
-      "version": "0.1.0-alpha.10",
-      "license": "MIT",
+      "version": "0.1.0-rc.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@echopath-labs/opendomain",
-  "version": "0.1.0-alpha.10",
+  "version": "0.1.0-rc.1",
   "description": "Git-native, evidence-backed domain semantics for AI agents.",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "author": {
     "name": "Chase",
     "email": "chasechou007@gmail.com"
@@ -53,12 +53,13 @@
     "CONTRIBUTING.md",
     "SECURITY.md",
     "LICENSE",
+    "NOTICE",
     "CHANGELOG.md"
   ],
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/",
-    "tag": "alpha"
+    "tag": "rc"
   },
   "scripts": {
     "test": "node --test",

--- a/scripts/smoke-agent-bootstrap.mjs
+++ b/scripts/smoke-agent-bootstrap.mjs
@@ -15,6 +15,7 @@ import { fileURLToPath } from "node:url";
 
 const execFile = promisify(execFileCallback);
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const expectedVersion = JSON.parse(await readFile(path.join(packageRoot, "package.json"), "utf8")).version;
 const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "opendomain-agent-bootstrap-"));
 const npmEnvironment = {
   ...process.env,
@@ -56,7 +57,7 @@ try {
   await access(cli);
 
   const version = await run(cli, ["--version"], workspace);
-  assert.match(version.stdout.trim(), /^0\.1\.0-alpha\.\d+$/);
+  assert.equal(version.stdout.trim(), expectedVersion);
 
   const init = await runJsonCli(cli, [
     "init",

--- a/scripts/smoke-installed-package.mjs
+++ b/scripts/smoke-installed-package.mjs
@@ -75,6 +75,7 @@ try {
     "SECURITY.md",
     "CHANGELOG.md",
     "LICENSE",
+    "NOTICE",
     "examples/erp/README.md"
   ]) {
     await access(path.join(installedRoot, ...publicDocument.split("/")));

--- a/tests/packaged-resources.test.mjs
+++ b/tests/packaged-resources.test.mjs
@@ -17,8 +17,12 @@ test("packaged resources expose schemas, package metadata, and ERP files", async
   const exampleFiles = resources.listPackagedFiles("examples/erp/");
 
   assert.equal(packageMetadata.name, "@echopath-labs/opendomain");
+  assert.equal(packageMetadata.version, "0.1.0-rc.1");
+  assert.equal(packageMetadata.license, "Apache-2.0");
+  assert.equal(packageMetadata.publishConfig.tag, "rc");
   assert.match(installationContract, /OpenDomain Agent Installation Contract/);
-  assert.match(installationContract, /@echopath-labs\/opendomain@alpha/);
+  assert.match(installationContract, /@echopath-labs\/opendomain@rc/);
+  assert.doesNotMatch(installationContract, /@echopath-labs\/opendomain@alpha/);
   assert.equal(schema.$id, "https://opendomain.dev/schemas/context.schema.json");
   assert.equal(governanceSchema.$id, "https://opendomain.dev/schemas/governance.schema.json");
   assert.equal(contextExportSchema.$id, "https://opendomain.dev/schemas/context-export.schema.json");

--- a/tests/public-docs.test.mjs
+++ b/tests/public-docs.test.mjs
@@ -34,8 +34,8 @@ const pairedNavigation = new Map([
 
 const npmPackageUrl =
   "https://www.npmjs.com/package/@echopath-labs/opendomain";
-const npmAlphaBadgeUrl =
-  "https://img.shields.io/npm/v/%40echopath-labs%2Fopendomain/alpha?label=npm";
+const npmRcBadgeUrl =
+  "https://img.shields.io/npm/v/%40echopath-labs%2Fopendomain/rc?label=npm%20rc";
 
 test("public guidance exposes paired Agent adoption entrypoints", async () => {
   for (const document of publicDocuments) {
@@ -58,16 +58,33 @@ test("public guidance exposes paired Agent adoption entrypoints", async () => {
   }
 });
 
-test("public READMEs expose the same alpha-aware npm package entrypoint", async () => {
-  const expectedBadge = `[![npm](${npmAlphaBadgeUrl})](${npmPackageUrl})`;
+test("public READMEs expose the same RC-aware npm package entrypoint", async () => {
+  const expectedBadge = `[![npm](${npmRcBadgeUrl})](${npmPackageUrl})`;
 
   for (const document of ["README.md", "README.zh-CN.md"]) {
     const content = await readDocument(document);
     assert.equal(
       content.split(expectedBadge).length - 1,
       1,
-      `${document} must contain exactly one linked npm alpha badge`
+      `${document} must contain exactly one linked npm RC badge`
     );
+  }
+});
+
+test("active installation guidance uses only the explicit RC channel", async () => {
+  for (const document of ["README.md", "README.zh-CN.md", "USAGE.md", "USAGE.zh-CN.md", "INSTALL.md"]) {
+    const content = await readDocument(document);
+    assert.match(content, /@echopath-labs\/opendomain@rc/);
+    assert.doesNotMatch(content, /@echopath-labs\/opendomain@alpha/);
+  }
+});
+
+test("RC guidance freezes the intended stable compatibility surface", async () => {
+  const english = await readDocument("README.md");
+  const chinese = await readDocument("README.zh-CN.md");
+  for (const phrase of ["Grounding Protocol v1", "Core API 1.0", "context-export v1"]) {
+    assert.match(english, new RegExp(phrase.replace(/[.-]/g, "\\$&")));
+    assert.match(chinese, new RegExp(phrase.replace(/[.-]/g, "\\$&")));
   }
 });
 


### PR DESCRIPTION
## Summary

- prepare the exact `0.1.0-rc.1` compatibility candidate from the canonical source-first projection
- move the forward release line to Apache-2.0 while preserving `0.1.0-alpha.10` and earlier as immutable MIT history
- align package metadata, lockfile, changelog, public installation/usage guidance, and RC-aware validation assertions
- use the explicit npm `rc` channel, which must not move `latest`

## Compatibility surface

This RC rehearses the intended first-stable surface: published Markdown/YAML schemas, Grounding Protocol v1, Core API 1.0, `opendomain.context-export.v1`, existing CLI/exit semantics, workspace resolution, and package-neutral npm/standalone behavior.

## Validation

- deterministic projection: 142 files / 744,547 bytes, inventory `1af1a00c3a3bbf10f5eb1054e88587ba7e48ad0f70d4e2c0891cf8b9387f005a`
- parity against `main@44f0250`: 126 identical / 16 reviewed intentional / 0 unexpected
- Node 20 and Node 22: 226/226 tests, validate, installed-package smoke, Agent bootstrap
- Node 24.18.0 standalone build/smoke
- npm pack dry-run: 72 entries / 104,378 bytes; audit: 0 vulnerabilities / 39 dependencies
- real corpus compatibility: Zimi PDM 32 docs, KeptNear 22 docs, EchoPath 8 docs; zero errors/warnings

## Approval boundary

This Draft PR is remote-integration evidence only. It does **not** authorize Ready-for-review, merge, `main` update, tag creation, npm publication or dist-tag changes, GitHub Release/standalone asset publication, branch-protection changes, repository lifecycle changes, or OpenSpec archive.